### PR TITLE
Types

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.5
 NLSolversBase 2.0
+Parameters

--- a/src/LineSearches.jl
+++ b/src/LineSearches.jl
@@ -11,9 +11,8 @@ export LineSearchResults, LineSearchException
 
 export clear!, alphatry, alphainit
 
-export hagerzhang!, backtracking!, strongwolfe!,
-    morethuente!, bt2!, bt3!, basic!,
-    BackTracking, HagerZhang, Static, MoreThuente, StrongWolfe
+export BackTracking, HagerZhang, Static, MoreThuente, StrongWolfe
+    
 
 include("types.jl")
 include("api.jl")

--- a/src/LineSearches.jl
+++ b/src/LineSearches.jl
@@ -13,7 +13,7 @@ export clear!, alphatry, alphainit
 
 export hagerzhang!, backtracking!, strongwolfe!,
     morethuente!, bt2!, bt3!, basic!,
-    BackTracking, HagerZhang, Static
+    BackTracking, HagerZhang, Static, MoreThuente, StrongWolfe
 
 include("types.jl")
 include("api.jl")

--- a/src/LineSearches.jl
+++ b/src/LineSearches.jl
@@ -13,7 +13,7 @@ export clear!, alphatry, alphainit
 
 export hagerzhang!, backtracking!, strongwolfe!,
     morethuente!, bt2!, bt3!, basic!,
-    BackTracking
+    BackTracking, HagerZhang, Static
 
 include("types.jl")
 include("api.jl")

--- a/src/LineSearches.jl
+++ b/src/LineSearches.jl
@@ -2,6 +2,8 @@ isdefined(Base, :__precompile__) && __precompile__()
 
 module LineSearches
 
+using Parameters
+
 import NLSolversBase
 import Base.clear!
 
@@ -10,7 +12,8 @@ export LineSearchResults, LineSearchException
 export clear!, alphatry, alphainit
 
 export hagerzhang!, backtracking!, strongwolfe!,
-    morethuente!, bt2!, bt3!, basic!
+    morethuente!, bt2!, bt3!, basic!,
+    BackTracking
 
 include("types.jl")
 include("api.jl")

--- a/src/backtracking.jl
+++ b/src/backtracking.jl
@@ -53,7 +53,8 @@ function backtracking!{T}(df,
                           rhohi::Real = 0.5,
                           rholo::Real = 0.1,
                           iterations::Integer = 1_000,
-                          order::Int = 3)
+                          order::Int = 3,
+                          maxstep::Real = Inf)
     @assert order in (2,3)
     # Check the input is valid, and modify otherwise
     #backtrack_condition = 1.0 - 1.0/(2*rho) # want guaranteed backtrack factor
@@ -120,7 +121,10 @@ function backtracking!{T}(df,
             end
         end
         alphatmp =  min(alphatmp, alpha*rhohi) # avoid too small reductions
-        alpha = max(alphatmp, alpha*rholo) # avoid too big reductions
+        alphatmp = max(alphatmp, alpha*rholo) # avoid too big reductions
+
+        # enforce a maximum step alpha * s (application specific, default is Inf)
+        alpha = max(alphatmp, maxstep / vecnorm(s, Inf))
 
         push!(lsr.alpha, alpha)
 

--- a/src/backtracking.jl
+++ b/src/backtracking.jl
@@ -1,5 +1,5 @@
 """
-`backtracking!` is a backtracking line-search that uses
+`BackTracking` specifies a backtracking line-search that uses
 a quadratic or cubic interpolant to determine the reduction in step-size.
 E.g.,
 if f(α) > f(0) + c₁ α f'(0), then the quadratic interpolant of
@@ -8,37 +8,18 @@ there exists a factor ρ = ρ(c₁) such that α' ≦ ρ α.
 
 This is a modification of the algorithm described in Nocedal Wright (2nd ed), Sec. 3.5.
 """
+@with_kw immutable BackTracking{TF, TI}
+    c1::TF = 1e-4
+    rhohi::TF = 0.5
+    rholo::TF = 0.1
+    iterations::TI = 1_000
+    order::TI = 3
+    maxstep::TF = Inf
+end
 
-bt3!{T}(df,
-        x::Vector{T},
-        s::Vector,
-        x_scratch::Vector,
-        gr_scratch::Vector,
-        lsr::LineSearchResults,
-        alpha::Real = 1.0,
-        mayterminate::Bool = false,
-        c1::Real = 1e-4,
-        rhohi::Real = 0.5,
-        rholo::Real = 0.1,
-        iterations::Integer = 1_000) =
-            backtracking!(df,x,s,x_scratch,gr_scratch,
-                          lsr,alpha,mayterminate,c1,
-                          rhohi,rholo,iterations,3)
-bt2!{T}(df,
-        x::Vector{T},
-        s::Vector,
-        x_scratch::Vector,
-        gr_scratch::Vector,
-        lsr::LineSearchResults,
-        alpha::Real = 1.0,
-        mayterminate::Bool = false,
-        c1::Real = 1e-4,
-        rhohi::Real = 0.5,
-        rholo::Real = 0.1,
-        iterations::Integer = 1_000) =
-            backtracking!(df,x,s,x_scratch,gr_scratch,
-                          lsr,alpha,mayterminate,c1,
-                          rhohi,rholo,iterations,2)
+(ls::BackTracking)(df, x, s, x_scratch, gr_scratch, lsr, alpha, mayterminate) =
+    backtracking!(df, x, s, x_scratch, gr_scratch, lsr, alpha, mayterminate,
+             ls.c1, ls.rhohi, ls.rholo, ls.iterations, ls.order, ls.maxstep)
 
 
 function backtracking!{T}(df,

--- a/src/backtracking.jl
+++ b/src/backtracking.jl
@@ -18,11 +18,11 @@ This is a modification of the algorithm described in Nocedal Wright (2nd ed), Se
 end
 
 (ls::BackTracking)(df, x, s, x_scratch, gr_scratch, lsr, alpha, mayterminate) =
-    backtracking!(df, x, s, x_scratch, gr_scratch, lsr, alpha, mayterminate,
+    _backtracking!(df, x, s, x_scratch, gr_scratch, lsr, alpha, mayterminate,
              ls.c1, ls.rhohi, ls.rholo, ls.iterations, ls.order, ls.maxstep)
 
 
-function backtracking!{T}(df,
+function _backtracking!{T}(df,
                           x::Vector{T},
                           s::Vector,
                           x_scratch::Vector,

--- a/src/backtracking.jl
+++ b/src/backtracking.jl
@@ -105,7 +105,7 @@ function backtracking!{T}(df,
         alphatmp = max(alphatmp, alpha*rholo) # avoid too big reductions
 
         # enforce a maximum step alpha * s (application specific, default is Inf)
-        alpha = max(alphatmp, maxstep / vecnorm(s, Inf))
+        alpha = min(alphatmp, maxstep / vecnorm(s, Inf))
 
         push!(lsr.alpha, alpha)
 

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -11,9 +11,9 @@ with `Static(alpha = 0.3141)` for fixed step-size 0.3141. Default is 1.0.
 end
 
 (ls::Static)(df, x, s, x_scratch, gr_scratch, lsr, alpha, mayterminate) =
-        basic!(df, x, s, x_scratch, gr_scratch, lsr, ls.alpha, mayterminate)
+        _static!(df, x, s, x_scratch, gr_scratch, lsr, ls.alpha, mayterminate)
 
-function basic!{T}(df,
+function _static!{T}(df,
                    x::Vector{T},
                    s::Vector,
                    x_scratch::Vector,

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -2,6 +2,17 @@
 # alpha in the search direction. By default, alpha = 1.0 is the full step.
 # This algorithm is intended for methods with well-scaled updates; i.e. Newton, on well-behaved problems.
 
+"""
+`Static`: defines a static linesearch, i.e. with fixed step-size. E.g., initialise
+with `Static(alpha = 0.3141)` for fixed step-size 0.3141. Default is 1.0.
+"""
+@with_kw immutable Static{T}
+    alpha::T = 1.0
+end
+
+(ls::Static)(df, x, s, x_scratch, gr_scratch, lsr, alpha, mayterminate) =
+        basic!(df, x, s, x_scratch, gr_scratch, lsr, ls.alpha, mayterminate)
+
 function basic!{T}(df,
                    x::Vector{T},
                    s::Vector,

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -1,33 +1,60 @@
 # Deprecation warnings
 
-Base.@deprecate(bt3!{T}(df,
-        x::Vector{T},
-        s::Vector,
-        x_scratch::Vector,
-        gr_scratch::Vector,
-        lsr::LineSearchResults,
-        alpha::Real = 1.0,
-        mayterminate::Bool = false,
-        c1::Real = 1e-4,
-        rhohi::Real = 0.5,
-        rholo::Real = 0.1,
-        iterations::Integer = 1_000),
-            backtracking!(df,x,s,x_scratch,gr_scratch,
-                          lsr,alpha,mayterminate,c1,
-                          rhohi,rholo,iterations,3))
+# >>>>>>>> Deprecation warnings for linesearch functions (vs types)
 
-Base.@deprecate(bt2!{T}(df,
-        x::Vector{T},
-        s::Vector,
-        x_scratch::Vector,
-        gr_scratch::Vector,
-        lsr::LineSearchResults,
-        alpha::Real = 1.0,
-        mayterminate::Bool = false,
-        c1::Real = 1e-4,
-        rhohi::Real = 0.5,
-        rholo::Real = 0.1,
-        iterations::Integer = 1_000),
-            backtracking!(df,x,s,x_scratch,gr_scratch,
-                          lsr,alpha,mayterminate,c1,
-                          rhohi,rholo,iterations,2))
+export hagerzhang!, backtracking!, strongwolfe!,
+    morethuente!, bt2!, bt3!, basic!
+
+const dep_bt2 = Ref(false)
+const dep_bt3 = Ref(false)
+const dep_backtracking = Ref(false)
+const dep_basic = Ref(false)
+const dep_strongwolfe = Ref(false)
+const dep_morethuente = Ref(false)
+const dep_hagerzhang = Ref(false)
+
+function _deprecate(msg, depvar, lsfun, args...)
+   if depvar[] == false
+      warn(msg)
+      depvar[] = true
+   end
+   return lsfun(args...)
+end
+
+_bt3!(args...) = _backtracking!(args...)
+
+_bt2!(df, x, s, x_scratch, gr_scratch, lsr, alpha, mayterminate,
+      c1::Real = 1e-4, rhohi::Real = 0.5, rholo::Real = 0.1, iterations::Integer = 1_000) =
+      _backtracking!(df, x, s, x_scratch, gr_scratch, lsr, alpha, mayterminate,
+                     c1, rhohi, rholo, iterations, 2)
+
+
+bt3!(args...) = _deprecate(
+   "`bt3!` is deprecated, use `BackTracking()` instead",
+   dep_bt3, _bt3!, args...)
+
+bt2!(args...) = _deprecate(
+   "`bt2!` is deprecated, use `BackTracking(order = 2)` instead",
+   dep_bt2, _bt2!, args...)
+
+backtracking!(args...) = _deprecate(
+   "`backtracking!` is deprecated, use `BackTracking()` instead",
+   dep_backtracking, _backtracking!, args...)
+
+strongwolfe!(args...) = _deprecate(
+   "`strongwolfe!` is deprecated, use `StrongWolfe()` instead",
+   dep_strongwolfe, _strongwolfe!, args...)
+
+morethuente!(args...) = _deprecate(
+   "`morethuente!` is deprecated, use `MoreThuente()` instead",
+   dep_morethuente, _morethuente!, args...)
+
+hagerzhang!(args...) = _deprecate(
+   "`hagerzhang!` is deprecated, use `HagerZhang()` instead",
+   dep_hagerzhang, _hagerzhang!, args...)
+
+basic!(args...) = _deprecate(
+   "`basic!` is deprecated, use `Static()` instead",
+   dep_basic, _static!, args...)
+
+# <<<<<<<<<<<< end deprecation warnings for linesearch functions

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -1,6 +1,6 @@
 # Deprecation warnings
 
-bt3!{T}(df,
+Base.@deprecate(bt3!{T}(df,
         x::Vector{T},
         s::Vector,
         x_scratch::Vector,
@@ -11,12 +11,12 @@ bt3!{T}(df,
         c1::Real = 1e-4,
         rhohi::Real = 0.5,
         rholo::Real = 0.1,
-        iterations::Integer = 1_000) =
+        iterations::Integer = 1_000),
             backtracking!(df,x,s,x_scratch,gr_scratch,
                           lsr,alpha,mayterminate,c1,
-                          rhohi,rholo,iterations,3)
+                          rhohi,rholo,iterations,3))
 
-bt2!{T}(df,
+Base.@deprecate(bt2!{T}(df,
         x::Vector{T},
         s::Vector,
         x_scratch::Vector,
@@ -27,7 +27,7 @@ bt2!{T}(df,
         c1::Real = 1e-4,
         rhohi::Real = 0.5,
         rholo::Real = 0.1,
-        iterations::Integer = 1_000) =
+        iterations::Integer = 1_000),
             backtracking!(df,x,s,x_scratch,gr_scratch,
                           lsr,alpha,mayterminate,c1,
-                          rhohi,rholo,iterations,2)
+                          rhohi,rholo,iterations,2))

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -1,1 +1,33 @@
 # Deprecation warnings
+
+bt3!{T}(df,
+        x::Vector{T},
+        s::Vector,
+        x_scratch::Vector,
+        gr_scratch::Vector,
+        lsr::LineSearchResults,
+        alpha::Real = 1.0,
+        mayterminate::Bool = false,
+        c1::Real = 1e-4,
+        rhohi::Real = 0.5,
+        rholo::Real = 0.1,
+        iterations::Integer = 1_000) =
+            backtracking!(df,x,s,x_scratch,gr_scratch,
+                          lsr,alpha,mayterminate,c1,
+                          rhohi,rholo,iterations,3)
+
+bt2!{T}(df,
+        x::Vector{T},
+        s::Vector,
+        x_scratch::Vector,
+        gr_scratch::Vector,
+        lsr::LineSearchResults,
+        alpha::Real = 1.0,
+        mayterminate::Bool = false,
+        c1::Real = 1e-4,
+        rhohi::Real = 0.5,
+        rholo::Real = 0.1,
+        iterations::Integer = 1_000) =
+            backtracking!(df,x,s,x_scratch,gr_scratch,
+                          lsr,alpha,mayterminate,c1,
+                          rhohi,rholo,iterations,2)

--- a/src/hagerzhang.jl
+++ b/src/hagerzhang.jl
@@ -63,7 +63,7 @@ const DEFAULTSIGMA = 0.9
 #       inferred from the input vector `x` and not from the type information
 #       on the parameters
 
-@with_kw type HagerZhang{T}
+@with_kw immutable HagerZhang{T}
    delta::T = DEFAULTDELTA
    sigma::T = DEFAULTSIGMA
    alphamax::T = Inf

--- a/src/hagerzhang.jl
+++ b/src/hagerzhang.jl
@@ -75,12 +75,12 @@ const DEFAULTSIGMA = 0.9
    display::Int = 0
 end
 
-(ls::HagerZhang)(args...) = hagerzhang!(args...,
+(ls::HagerZhang)(args...) = _hagerzhang!(args...,
       ls.delta, ls.sigma, ls.alphamax, ls.rho, ls.epsilon, ls.gamma,
       ls.linesearchmax, ls.psi3, ls.display)
 
 
-function hagerzhang!{T}(df,
+function _hagerzhang!{T}(df,
                         x::Array{T},
                         s::Array,
                         xtmp::Array,

--- a/src/hagerzhang.jl
+++ b/src/hagerzhang.jl
@@ -54,6 +54,32 @@ display_nextbit = 14
 const DEFAULTDELTA = 0.1
 const DEFAULTSIGMA = 0.9
 
+
+# NOTE:
+#   [1] The type `T` in the `HagerZhang{T}` need not be the same `T` as in
+#       `hagerzhang!{T}`; in the latter, `T` comes from the input vector `x`.
+#   [2] the only method parameter that is not included in the
+#       type is `iterfinitemax` since this value needs to be
+#       inferred from the input vector `x` and not from the type information
+#       on the parameters
+
+@with_kw type HagerZhang{T}
+   delta::T = DEFAULTDELTA
+   sigma::T = DEFAULTSIGMA
+   alphamax::T = Inf
+   rho::T = 5.0
+   epsilon::T = 1e-6
+   gamma::T = 0.66
+   linesearchmax::Int = 50
+   psi3::T = 0.1
+   display::Int = 0
+end
+
+(ls::HagerZhang)(args...) = hagerzhang!(args...,
+      ls.delta, ls.sigma, ls.alphamax, ls.rho, ls.epsilon, ls.gamma,
+      ls.linesearchmax, ls.psi3, ls.display)
+
+
 function hagerzhang!{T}(df,
                         x::Array{T},
                         s::Array,
@@ -70,8 +96,8 @@ function hagerzhang!{T}(df,
                         gamma::Real = convert(T,0.66),
                         linesearchmax::Integer = 50,
                         psi3::Real = convert(T,0.1),
-                        iterfinitemax::Integer = ceil(Integer, -log2(eps(T))),
-                        display::Integer = 0)
+                        display::Integer = 0,
+                        iterfinitemax::Integer = ceil(Integer, -log2(eps(T))) )
     # TODO: do we need g anymore?
     # Any call to gradient! or value_gradient! would update df.g anyway
 

--- a/src/morethuente.jl
+++ b/src/morethuente.jl
@@ -143,11 +143,11 @@
 end
 
 (ls::MoreThuente)(args...) =
-       morethuente!(args...;
+       _morethuente!(args...;
                    f_tol=ls.f_tol, gtol=ls.gtol, x_tol=ls.x_tol, stpmin=ls.stpmin,
                    stpmax=ls.stpmax, maxfev=ls.maxfev)
 
-function morethuente!{T}(df,
+function _morethuente!{T}(df,
                          x::Vector,
                          s::Vector,
                          x_new::Vector,

--- a/src/morethuente.jl
+++ b/src/morethuente.jl
@@ -132,6 +132,21 @@
 # TODO: Decide whether to update x, f, g and info
 #       or just return step and nfev and let existing code do its job
 
+
+@with_kw immutable MoreThuente{T}
+    f_tol::T = 1e-4
+    gtol::T = 0.9
+    x_tol::T = 1e-8
+    stpmin::T = 1e-16
+    stpmax::T = 65536.0
+    maxfev::Int = 100
+end
+
+(ls::MoreThuente)(args...) =
+       morethuente!(args...;
+                   f_tol=ls.f_tol, gtol=ls.gtol, x_tol=ls.x_tol, stpmin=ls.stpmin,
+                   stpmax=ls.stpmax, maxfev=ls.maxfev)
+
 function morethuente!{T}(df,
                          x::Vector,
                          s::Vector,

--- a/src/strongwolfe.jl
+++ b/src/strongwolfe.jl
@@ -1,8 +1,27 @@
 # TODO: Implement safeguards
 
-# This linesearch algorithm guarantees that the step length
-# satisfies the (strong) Wolfe conditions.
-# See Nocedal and Wright - Algorithms 3.5 and 3.6
+
+"""
+`StrongWolfe`: This linesearch algorithm guarantees that the step length
+satisfies the (strong) Wolfe conditions.
+See Nocedal and Wright - Algorithms 3.5 and 3.6
+
+This algorithm is mostly of theoretical interest, users should most likely
+use `MoreThuente`, `HagerZhang` or `BackTracking`.
+
+## Parameters:  (and defaults)
+* `c1 = 1e-4`: Armijo condition
+* `c2 = 0.9` : second (strong) Wolfe condition
+* `rho = 2.0` : bracket growth
+"""
+@with_kw immutable StrongWolfe{T}
+   c1::T = 1e-4
+   c2::T = 0.9
+   rho::T = 2.0
+end
+
+(ls::StrongWolfe)(args...) =
+        strongwolfe!(args...; c1=ls.c1, c2=ls.c2, rho=ls.rho)
 
 function strongwolfe!{T}(df,
                          x::Vector,

--- a/src/strongwolfe.jl
+++ b/src/strongwolfe.jl
@@ -21,9 +21,9 @@ use `MoreThuente`, `HagerZhang` or `BackTracking`.
 end
 
 (ls::StrongWolfe)(args...) =
-        strongwolfe!(args...; c1=ls.c1, c2=ls.c2, rho=ls.rho)
+        _strongwolfe!(args...; c1=ls.c1, c2=ls.c2, rho=ls.rho)
 
-function strongwolfe!{T}(df,
+function _strongwolfe!{T}(df,
                          x::Vector,
                          p::Vector,
                          x_new::Vector,

--- a/src/types.jl
+++ b/src/types.jl
@@ -10,10 +10,10 @@ LineSearchResults{T}(::Type{T}) = LineSearchResults(T[], T[], T[], 0)
 
 Base.length(lsr::LineSearchResults) = length(lsr.alpha)
 
-function Base.push!{T}(lsr::LineSearchResults{T}, a::T, v::T, d::T)
-    push!(lsr.alpha, a)
-    push!(lsr.value, v)
-    push!(lsr.slope, d)
+function Base.push!{T}(lsr::LineSearchResults{T}, a, v, d)
+    push!(lsr.alpha, convert(T, a))
+    push!(lsr.value, convert(T, v))
+    push!(lsr.slope, convert(T, d))
     return
 end
 

--- a/test/alphacalc.jl
+++ b/test/alphacalc.jl
@@ -1,9 +1,9 @@
 let
     import NLSolversBase
 
-    lsalphas = [1.0, 0.5,0.5,0.49995,0.5,0.5,0.5,
-                1.0,   0.5, 0.5,  0.5]
-                # Stat #HZ  bt2   bt3
+    lsalphas = [1.0,   0.5, 0.5, 0.49995, 0.5,  0.5,  0.5,  # function calls
+                1.0,   0.5, 0.5, 0.49995,       0.5,  0.5]  # types
+                # Stat #HZ  wolfe   mt          bt2   bt3
 
     f(x) = vecdot(x, x)
     function g!(out, x)

--- a/test/alphacalc.jl
+++ b/test/alphacalc.jl
@@ -1,9 +1,9 @@
 let
     import NLSolversBase
 
-    lsalphas = [1.0,   0.5, 0.5, 0.49995, 0.5,  0.5,  0.5,  # function calls
-                1.0,   0.5, 0.5, 0.49995,       0.5,  0.5]  # types
-                # Stat #HZ  wolfe   mt          bt2   bt3
+    dep_lsalphas = [1.0,   0.5, 0.5, 0.49995, 0.5,  0.5,  0.5]  # functions
+    lsalphas =     [1.0,   0.5, 0.5, 0.49995,       0.5,  0.5]  # types
+                    # Stat #HZ  wolfe   mt          bt2   bt3
 
     f(x) = vecdot(x, x)
     function g!(out, x)
@@ -11,6 +11,9 @@ let
     end
 
     x = [-1., -1.]
+
+    lsfunctions = tuple(dep_lsfunctions..., lstypes...)
+    lsalphas = [dep_lsalphas; lsalphas]
 
     for (i, linesearch!) in enumerate(lsfunctions)
         println("Testing $(string(linesearch!))")

--- a/test/alphacalc.jl
+++ b/test/alphacalc.jl
@@ -1,7 +1,9 @@
 let
     import NLSolversBase
 
-    lsalphas = [1.0, 0.5,0.5,0.49995,0.5,0.5,0.5, 0.5, 0.5]
+    lsalphas = [1.0, 0.5,0.5,0.49995,0.5,0.5,0.5,
+                1.0,   0.5, 0.5,  0.5]
+                # Stat #HZ  bt2   bt3
 
     f(x) = vecdot(x, x)
     function g!(out, x)

--- a/test/alphacalc.jl
+++ b/test/alphacalc.jl
@@ -1,7 +1,7 @@
 let
     import NLSolversBase
 
-    lsalphas = [1.0, 0.5,0.5,0.49995,0.5,0.5,0.5]
+    lsalphas = [1.0, 0.5,0.5,0.49995,0.5,0.5,0.5, 0.5, 0.5]
 
     f(x) = vecdot(x, x)
     function g!(out, x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,11 @@
 using LineSearches
 using Base.Test
 
-lsfunctions = (basic!, hagerzhang!, strongwolfe!,
-               morethuente!, backtracking!,
-               bt2!, bt3!,
-               Static(), HagerZhang(), StrongWolfe(), MoreThuente(),
-               BackTracking(), BackTracking(order=2) )
+lstypes =  (Static(), HagerZhang(), StrongWolfe(), MoreThuente(),
+            BackTracking(), BackTracking(order=2) )
+
+dep_lsfunctions = (basic!, hagerzhang!, strongwolfe!, morethuente!,
+                  backtracking!, bt2!, bt3!)
 
 println("Running tests:")
 my_tests = [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using Base.Test
 lsfunctions = (basic!, hagerzhang!, strongwolfe!,
                morethuente!, backtracking!,
                bt2!, bt3!,
-               BackTracking(), BackTracking(order=2))
+               Static(), HagerZhang(), BackTracking(), BackTracking(order=2) )
 
 println("Running tests:")
 my_tests = [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,8 @@ using Base.Test
 
 lsfunctions = (basic!, hagerzhang!, strongwolfe!,
                morethuente!, backtracking!,
-               bt2!, bt3!)
+               bt2!, bt3!,
+               BackTracking(), BackTracking(order=2))
 
 println("Running tests:")
 my_tests = [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,8 @@ using Base.Test
 lsfunctions = (basic!, hagerzhang!, strongwolfe!,
                morethuente!, backtracking!,
                bt2!, bt3!,
-               Static(), HagerZhang(), BackTracking(), BackTracking(order=2) )
+               Static(), HagerZhang(), StrongWolfe(), MoreThuente(),
+               BackTracking(), BackTracking(order=2) )
 
 println("Running tests:")
 my_tests = [


### PR DESCRIPTION
I suggest to not merge this yet. This is just a proof-of-concept for `backtracking!` only. Please have a quick look - if you are happy then I'll try to do the same for the remaining line searches.

Notes: 
 * This PR will give - for the user - the functionality of using types instead of functions for LS, but internally very little has changed. Both of you (@pkofod and @anriseth)  are probably better placed to carry out the internal changes. (though time permitting I'm obviously happy to do this too)
 * While I was at it, I also made a small addition to `backtracking!` adding a `maxstep` parameter; this requires that `alpha * vecnorm(s, inf) <= maxstep`. (the choice of norm is a little restrictive, but I'll do another PR later when this is done to generalise to arbitrary step-length constraints).

Please, somebody double-check that I've deprecated `bt2!` and `bt3!` correctly.