### PR TITLE
Allow scaled versions of Static

### DIFF
--- a/test/alphacalc.jl
+++ b/test/alphacalc.jl
@@ -7,8 +7,8 @@
     end
 
     @testset "Quadratic function" begin
-        lsalphas =     [1.0,   0.5, 0.5, 0.49995, 0.5,  0.5]  # types
-                        # Stat #HZ  wolfe   mt    bt2   bt3
+        lsalphas =     [1.0,   0.35355339059327373, 0.5, 0.5, 0.49995, 0.5,  0.5]  # types
+                        # Stat # Stat(scaled)       #HZ  wolfe   mt    bt2   bt3
         x = [-1., -1.]
 
         for (i, linesearch!) in enumerate(lstypes)
@@ -73,10 +73,11 @@
 
         mayterminate = false; alpha = 1.0; xtmp = zeros(x0)
 
-        lsalphas =  [1.0, # Stat
-                     0.01375274240750926, # HZ
+        lsalphas =  [1.0,                  # Static(scaled)
+                     0.021884405476620426, # Static(scaled)
+                     0.01375274240750926,  # HZ
                      0.020646100006834013, # Wolfe
-                     0.0175892025844326, # MT
+                     0.0175892025844326,   # MT
                      0.020545340808876406, # BT(2)
                      0.010000000000000002] # BT(3)
         for (i, ls) in enumerate(lstypes)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using OptimTestProblems
 
 debug_printing = false
 
-lstypes =  (Static(), HagerZhang(), StrongWolfe(), MoreThuente(),
+lstypes =  (Static(), Static(scaled=true), HagerZhang(), StrongWolfe(), MoreThuente(),
             BackTracking(), BackTracking(order=2) )
 
 my_tests = [


### PR DESCRIPTION
For the Static linesearch, I have use cases where it is useful to have a step size that is static, relative to the direction norm.