### PR TITLE
Fixes to MoreThuente

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# LineSearches v3.2.2 release notes
+- Ensure finite initial values and fix typos in original MoreThuente translation from MATLAB/FORTRAN implementations. See [#75](https://github.com/anriseth/LineSearches.jl/pull/75)
+
 # LineSearches v3.2.0 release notes
 - Introduce initial step length procedures. See [#70](https://github.com/anriseth/LineSearches.jl/pull/70)
 

--- a/src/morethuente.jl
+++ b/src/morethuente.jl
@@ -496,7 +496,7 @@ function cstep(stx::Real, fx::Real, dgx::Real,
       bound = true
       theta = 3 * (fx - f) / (stp - stx) + dgx + dg
       # Original code from FORTRAN implementation
-      # s = maxabs(theta, dgx, dg)
+      # s = maximum(abs,[theta, dgx, dg])
       # gamma = s * sqrt((theta / s)^2 - (dgx / s) * (dg / s))
       # The s cancels if you move it inside the sqrt?????
       gamma = sqrt(theta^2 - dgx * dg)
@@ -527,7 +527,7 @@ function cstep(stx::Real, fx::Real, dgx::Real,
       bound = false
       theta = 3 * (fx - f) / (stp - stx) + dgx + dg
       # Original code from FORTRAN implementation
-      # s = maxabs(theta, dgx, dg)
+      # s = maximum(abs,[theta, dgx, dg])
       # gamma = s * sqrt((theta / s)^2 - (dgx / s) * (dg / s))
       # The s cancels if you move it inside the sqrt?????
       gamma = sqrt(theta^2 - dgx * dg)
@@ -563,7 +563,7 @@ function cstep(stx::Real, fx::Real, dgx::Real,
       bound = true
       theta = 3 * (fx - f) / (stp - stx) + dgx + dg
       # Original code from FORTRAN implementation
-      # s = maxabs(theta, dgx, dg)
+      # s = maximum(abs,[theta, dgx, dg])
       # #
       # # The case gamma = 0 only arises if the cubic does not tend
       # # to infinity in the direction of the step
@@ -613,7 +613,7 @@ function cstep(stx::Real, fx::Real, dgx::Real,
       if bracketed
          theta = 3 * (f - fy) / (sty - stp) + dgy + dg
          # Original code from FORTRAN implementation
-         # s = maxabs(theta, dgy, dg)
+         # s = maximum(abs,[theta, dgy, dg])
          # gamma = s * sqrt((theta / s)^2 - (dgy / s) * (dg / s))
          # The s cancels if you move it inside the sqrt?????
          gamma = sqrt(theta^2 - dgy * dg)

--- a/src/morethuente.jl
+++ b/src/morethuente.jl
@@ -495,11 +495,9 @@ function cstep(stx::Real, fx::Real, dgx::Real,
       info = 1
       bound = true
       theta = 3 * (fx - f) / (stp - stx) + dgx + dg
-      # Original code from FORTRAN implementation
-      # s = maximum(abs,[theta, dgx, dg])
-      # gamma = s * sqrt((theta / s)^2 - (dgx / s) * (dg / s))
-      # The s cancels if you move it inside the sqrt?????
-      gamma = sqrt(theta^2 - dgx * dg)
+      # Use s to prevent overflow/underflow of theta^2 and dgx * dg
+      s = max(abs(theta), abs(dgx), abs(dg))
+      gamma = s * sqrt((theta / s)^2 - (dgx / s) * (dg / s))
       if stp < stx
           gamma = -gamma
       end
@@ -526,11 +524,9 @@ function cstep(stx::Real, fx::Real, dgx::Real,
       info = 2
       bound = false
       theta = 3 * (fx - f) / (stp - stx) + dgx + dg
-      # Original code from FORTRAN implementation
-      # s = maximum(abs,[theta, dgx, dg])
-      # gamma = s * sqrt((theta / s)^2 - (dgx / s) * (dg / s))
-      # The s cancels if you move it inside the sqrt?????
-      gamma = sqrt(theta^2 - dgx * dg)
+      # Use s to prevent overflow/underflow of theta^2 and dgx * dg
+      s = max(abs(theta), abs(dgx), abs(dg))
+      gamma = s * sqrt((theta / s)^2 - (dgx / s) * (dg / s))
 
       if stp > stx
          gamma = -gamma
@@ -562,15 +558,14 @@ function cstep(stx::Real, fx::Real, dgx::Real,
       info = 3
       bound = true
       theta = 3 * (fx - f) / (stp - stx) + dgx + dg
-      # Original code from FORTRAN implementation
-      # s = maximum(abs,[theta, dgx, dg])
-      # #
-      # # The case gamma = 0 only arises if the cubic does not tend
-      # # to infinity in the direction of the step
-      # #
-      # gamma = s * sqrt(max(0.0, (theta / s)^2 - (dgx / s) * (dg / s)))
-      # The s cancels if you move it inside the sqrt?????
-      gamma = sqrt(max(zero(theta), theta^2 - dgx * dg))
+      # Use s to prevent overflow/underflow of theta^2 and dgx * dg
+      s = max(abs(theta), abs(dgx), abs(dg))
+      #
+      # The case gamma = 0 only arises if the cubic does not tend
+      # to infinity in the direction of the step
+      #
+      #
+      gamma = (s > zero(s)) ? s * sqrt((theta / s)^2 - (dgx / s) * (dg / s)) : zero(s)
 
       if stp > stx
           gamma = -gamma
@@ -612,11 +607,9 @@ function cstep(stx::Real, fx::Real, dgx::Real,
       bound = false
       if bracketed
          theta = 3 * (f - fy) / (sty - stp) + dgy + dg
-         # Original code from FORTRAN implementation
-         # s = maximum(abs,[theta, dgy, dg])
-         # gamma = s * sqrt((theta / s)^2 - (dgy / s) * (dg / s))
-         # The s cancels if you move it inside the sqrt?????
-         gamma = sqrt(theta^2 - dgy * dg)
+         # Use s to prevent overflow/underflow of theta^2 and dgy * dg
+         s = max(abs(theta), abs(dgy), abs(dg))
+         gamma = s * sqrt((theta / s)^2 - (dgy / s) * (dg / s))
 
          if stp > sty
              gamma = -gamma

--- a/src/morethuente.jl
+++ b/src/morethuente.jl
@@ -495,8 +495,11 @@ function cstep(stx::Real, fx::Real, dgx::Real,
       info = 1
       bound = true
       theta = 3 * (fx - f) / (stp - stx) + dgx + dg
-      s = max(theta, dgx, dg)
-      gamma = s * sqrt((theta / s)^2 - (dgx / s) * (dg / s))
+      # Original code from FORTRAN implementation
+      # s = maxabs(theta, dgx, dg)
+      # gamma = s * sqrt((theta / s)^2 - (dgx / s) * (dg / s))
+      # The s cancels if you move it inside the sqrt?????
+      gamma = sqrt(theta^2 - dgx * dg)
       if stp < stx
           gamma = -gamma
       end
@@ -504,11 +507,11 @@ function cstep(stx::Real, fx::Real, dgx::Real,
       q = gamma - dgx + gamma + dg
       r = p / q
       stpc = stx + r * (stp - stx)
-      stpq = stx + ((dgx / ((fx - f) / (stp - stx) + dgx)) / 2) * (stp - stx)
+      stpq = stx + 0.5 * (dgx / ((fx - f) / (stp - stx) + dgx)) * (stp - stx)
       if abs(stpc - stx) < abs(stpq - stx)
          stpf = stpc
       else
-         stpf = stpc + (stpq - stpc) / 2
+         stpf = 0.5*(stpc + stpq)
       end
       bracketed = true
 
@@ -523,8 +526,12 @@ function cstep(stx::Real, fx::Real, dgx::Real,
       info = 2
       bound = false
       theta = 3 * (fx - f) / (stp - stx) + dgx + dg
-      s = max(theta, dgx, dg)
-      gamma = s * sqrt((theta / s)^2 - (dgx / s) * (dg / s))
+      # Original code from FORTRAN implementation
+      # s = maxabs(theta, dgx, dg)
+      # gamma = s * sqrt((theta / s)^2 - (dgx / s) * (dg / s))
+      # The s cancels if you move it inside the sqrt?????
+      gamma = sqrt(theta^2 - dgx * dg)
+
       if stp > stx
          gamma = -gamma
       end
@@ -555,12 +562,16 @@ function cstep(stx::Real, fx::Real, dgx::Real,
       info = 3
       bound = true
       theta = 3 * (fx - f) / (stp - stx) + dgx + dg
-      s = max(theta, dgx, dg)
-      #
-      # The case gamma = 0 only arises if the cubic does not tend
-      # to infinity in the direction of the step
-      #
-      gamma = s * sqrt(max(0.0, (theta / s)^2 - (dgx / s) * (dg / s)))
+      # Original code from FORTRAN implementation
+      # s = maxabs(theta, dgx, dg)
+      # #
+      # # The case gamma = 0 only arises if the cubic does not tend
+      # # to infinity in the direction of the step
+      # #
+      # gamma = s * sqrt(max(0.0, (theta / s)^2 - (dgx / s) * (dg / s)))
+      # The s cancels if you move it inside the sqrt?????
+      gamma = sqrt(max(zero(theta), theta^2 - dgx * dg))
+
       if stp > stx
           gamma = -gamma
       end
@@ -601,8 +612,12 @@ function cstep(stx::Real, fx::Real, dgx::Real,
       bound = false
       if bracketed
          theta = 3 * (f - fy) / (sty - stp) + dgy + dg
-         s = max(theta, dgy, dg)
-         gamma = s * sqrt((theta / s)^2 - (dgy / s) * (dg / s))
+         # Original code from FORTRAN implementation
+         # s = maxabs(theta, dgy, dg)
+         # gamma = s * sqrt((theta / s)^2 - (dgy / s) * (dg / s))
+         # The s cancels if you move it inside the sqrt?????
+         gamma = sqrt(theta^2 - dgy * dg)
+
          if stp > sty
              gamma = -gamma
          end


### PR DESCRIPTION
After looking through the MoreThuente code, I found that the original translation from the MATLAB code has a bug in it. There are several lines in `cstep` where a value `s = max(theta, dgx,dg)` is calculated. In the original [FORTRAN](http://www.cs.umd.edu/~oleary/LBFGS/FORTRAN/linesearch.f) and [MATLAB](https://github.com/andrewssobral/mtt/blob/master/libs/poblano_toolbox_1.1/cstep.m#L170)  codes, however, this is set to `s = max(abs(theta), abs(dgx), abs(dg))`.

I caught this when an optimization problem I was running broke down. It is a high-dimensional problem, and I can't replicate it in a test as the input values to the line search are shown in pretty-mode, and small changes in the eight decimal place mean that the problem does not appear...

There also seems to be a weird choice in the original codes where they calculate
`gamma = s* sqrt( (theta/s)^2 - (dg/s) * (dgx / s))`. As `s >= 0`, this should be equivalent (modulo floating points) to `gamma = sqrt( theta^2 - dg * dgx)`. I have made the change, as it omits the potentially problematic division by `s`.

In addition, I have moved the finite-value check from #73 outside the of loop, so that it does not interfere with the algorithm in itself, but only ensures that the initial step does not mess things up.

