### PR TITLE
Use vecnorm

### DIFF
--- a/src/initialguess.jl
+++ b/src/initialguess.jl
@@ -14,7 +14,7 @@ end
 
 function (is::InitialStatic{T})(state, dphi0, df) where T
     state.alpha = is.alpha
-    if is.scaled == true && (ns = norm(state.s)) > zero(T)
+    if is.scaled == true && (ns = vecnorm(state.s)) > zero(T)
         # TODO: Type instability if there's a type mismatch between is.alpha and ns
         state.alpha *= min(is.alpha, ns) / ns
     end

--- a/src/morethuente.jl
+++ b/src/morethuente.jl
@@ -161,7 +161,7 @@ function _morethuente!(df,
                       stpmin::Real = 1e-16,
                       stpmax::Real = 65536.0,
                        maxfev::Integer = 100) where T
-    if norm(s) == 0
+    if vecnorm(s) == 0
         Base.error("Step direction is zero.")
     end
     iterfinitemax = -log2(eps(T))
@@ -294,7 +294,7 @@ function _morethuente!(df,
         gdf = NLSolversBase.gradient(df)
         nfev += 1 # This includes calls to f() and g!()
 
-        if isapprox(norm(gdf), 0.0) # TODO: this should be tested vs Optim's g_tol
+        if isapprox(vecnorm(gdf), 0.0) # TODO: this should be tested vs Optim's g_tol
             return stp
         end
 

--- a/src/static.jl
+++ b/src/static.jl
@@ -18,7 +18,7 @@ end
 function (ls::Static)(df, x, s, x_scratch, lsr, alpha, mayterminate)
     # NOTE: alpha is ignored here, and we use ls.alpha instead
 
-    if ls.scaled == true && (ns = norm(s)) > zero(typeof(ls.alpha))
+    if ls.scaled == true && (ns = vecnorm(s)) > zero(typeof(ls.alpha))
         scaledalpha = min(ls.alpha, ns) / ns
         retval = _static!(df, x, s, x_scratch, lsr, scaledalpha, mayterminate)
     else


### PR DESCRIPTION
Currently, some of the algorithms call `norm` on the step directions or gradients, however, if we work with input objects such as `Array{Float64,3}`, then there is no norm function. To handle this, I changed to calling `vecnorm`. 

@antoine-levitt @cortner Is `vecnorm` a sensible norm to use when you optimize with inputs being complex numbers and/or from manifolds? Or do we need to support a user-defined norm function for these cases (in the future)?

BackTracking and HagerZhang already use `vecnorm`.