### PR TITLE
Remove scaling from Static 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ in `Optim`.
 * `MoreThuente` (From the algorithm in More and Thuente, 1994)
 * `BackTracking` (Described in Nocedal and Wright, 2006)
 * `StrongWolfe` (Nocedal and Wright)
-* `Static` (Simply takes a given step length, default 1.0)
+* `Static` (Takes the proposed initial step length.)
 
 ### Available initial step length procedures
 The package provides some procedures to calculate the initial step
@@ -54,12 +54,12 @@ Results of Optimization Algorithm
  * Minimum: 3.081488e-31
  * Iterations: 14
  * Convergence: true
-   * |x - x'| ≤ 1.0e-32: false 
-     |x - x'| = 3.06e-09 
+   * |x - x'| ≤ 1.0e-32: false
+     |x - x'| = 3.06e-09
    * |f(x) - f(x')| ≤ 1.0e-32 |f(x)|: false
      |f(x) - f(x')| = 3.03e+13 |f(x)|
-   * |g(x)| ≤ 1.0e-08: true 
-     |g(x)| = 1.11e-15 
+   * |g(x)| ≤ 1.0e-08: true
+     |g(x)| = 1.11e-15
    * Stopped by an increasing objective: false
    * Reached Maximum Number of Iterations: false
  * Objective Calls: 44
@@ -82,12 +82,12 @@ Results of Optimization Algorithm
  * Minimum: 1.667699e-17
  * Iterations: 14
  * Convergence: true
-   * |x - x'| ≤ 1.0e-32: false 
-     |x - x'| = 1.36e-05 
+   * |x - x'| ≤ 1.0e-32: false
+     |x - x'| = 1.36e-05
    * |f(x) - f(x')| ≤ 1.0e-32 |f(x)|: false
      |f(x) - f(x')| = 1.21e+08 |f(x)|
-   * |g(x)| ≤ 1.0e-08: true 
-     |g(x)| = 4.16e-09 
+   * |g(x)| ≤ 1.0e-08: true
+     |g(x)| = 4.16e-09
    * Stopped by an increasing objective: false
    * Reached Maximum Number of Iterations: false
  * Objective Calls: 19
@@ -117,12 +117,12 @@ Results of Optimization Algorithm
  * Minimum: 3.081488e-31
  * Iterations: 14
  * Convergence: true
-   * |x - x'| ≤ 1.0e-32: false 
-     |x - x'| = 3.06e-09 
+   * |x - x'| ≤ 1.0e-32: false
+     |x - x'| = 3.06e-09
    * |f(x) - f(x')| ≤ 1.0e-32 |f(x)|: false
      |f(x) - f(x')| = 3.03e+13 |f(x)|
-   * |g(x)| ≤ 1.0e-08: true 
-     |g(x)| = 1.11e-15 
+   * |g(x)| ≤ 1.0e-08: true
+     |g(x)| = 1.11e-15
    * Stopped by an increasing objective: false
    * Reached Maximum Number of Iterations: false
  * Objective Calls: 44
@@ -145,12 +145,12 @@ Results of Optimization Algorithm
  * Minimum: 6.535152e-18
  * Iterations: 15
  * Convergence: true
-   * |x - x'| ≤ 1.0e-32: false 
-     |x - x'| = 1.09e-05 
+   * |x - x'| ≤ 1.0e-32: false
+     |x - x'| = 1.09e-05
    * |f(x) - f(x')| ≤ 1.0e-32 |f(x)|: false
      |f(x) - f(x')| = 8.61e+08 |f(x)|
-   * |g(x)| ≤ 1.0e-08: true 
-     |g(x)| = 4.41e-09 
+   * |g(x)| ≤ 1.0e-08: true
+     |g(x)| = 4.41e-09
    * Stopped by an increasing objective: false
    * Reached Maximum Number of Iterations: false
  * Objective Calls: 36

--- a/src/static.jl
+++ b/src/static.jl
@@ -1,18 +1,66 @@
-# This linesearch does not perform a search at all, but takes the step
-# alpha in the search direction.
-# This algorithm is intended for methods with well-scaled updates; i.e. Newton, on well-behaved problems.
+# TODO: Remove deprecation by v6.0.0
+# - Delete `DeprecatedStatic` and the `Static(;kwargs...)` function
+# - Replace string `NewStatic` with Static
+
+##########################
+## DELETE FROM THIS LINE
+##########################
+function Static(;kwargs...)
+    if isempty(kwargs)
+        return NewStatic()
+    else
+        Base.warn_once("`Static` no longer has any parameters.
+Use together with `InitialStatic` if you wish to retain the old functionality.")
+        return DeprecatedStatic(;kwargs...)
+    end
+end
 
 """
-`Static`: defines a static linesearch which returns the initial step length.
+`DeprecatedStatic`: defines a static linesearch, i.e. with fixed step-size. E.g., initialise
+with `DeprecatedStatic(alpha = 0.3141)` for fixed step-size 0.3141. Default is 1.0.
+You can also make this independent of the size of the step `s`, by using
+`DeprecatedStatic(scaled = true)`.
+This will then use a step-size alpha ← min(alpha,||s||_2) / ||s||_2
 """
-immutable Static end
+@with_kw struct DeprecatedStatic{T}
+    alpha::T = 1.0
+    scaled::Bool = false # Scales step. alpha ← min(alpha,||s||_2) / ||s||_2
+end
 
-function (ls::Static)(df::AbstractObjective, x, s, α, x_new = similar(x), phi0 = nothing, dphi0 = nothing)
+function (ls::DeprecatedStatic)(df::AbstractObjective, x, s, α, x_new = similar(x), phi0 = nothing, dphi0 = nothing)
     ϕ = make_ϕ(df, x_new, x, s)
     ls(ϕ, x, s, α)
 end
 
-function (ls::Static)(ϕ, x, s, alpha)
+function (ls::DeprecatedStatic)(ϕ, x, s, alpha)
+    @unpack alpha, scaled = ls
+    @assert alpha > zero(typeof(alpha)) # This should really be done at the constructor level
+
+    if scaled == true && (ns = vecnorm(s)) > zero(typeof(alpha))
+        alpha = min(alpha, ns) / ns
+    end
+
+    ϕα = ϕ(alpha)
+
+    return alpha, ϕα
+end
+##########################
+## DELETE UNTIL THIS LINE
+##########################
+
+"""
+`NewStatic`: defines a static linesearch which returns the initial step length.
+
+`NewStatic` is intended for methods with well-scaled updates; i.e. Newton, on well-behaved problems.
+"""
+immutable NewStatic end
+
+function (ls::NewStatic)(df::AbstractObjective, x, s, α, x_new = similar(x), phi0 = nothing, dphi0 = nothing)
+    ϕ = make_ϕ(df, x_new, x, s)
+    ls(ϕ, x, s, α)
+end
+
+function (ls::NewStatic)(ϕ, x, s, alpha)
     ϕα = ϕ(alpha)
 
     return alpha, ϕα

--- a/src/static.jl
+++ b/src/static.jl
@@ -1,21 +1,11 @@
 # This linesearch does not perform a search at all, but takes the step
-# alpha in the search direction. By default, alpha = 1.0 is the full step.
+# alpha in the search direction.
 # This algorithm is intended for methods with well-scaled updates; i.e. Newton, on well-behaved problems.
-# NOTE: alpha passed from outside is ignored here, but can be passed to allow
-# for generic use. We use ls.alpha instead.
 
 """
-`Static`: defines a static linesearch, i.e. with fixed step-size. E.g., initialise
-with `Static(alpha = 0.3141)` for fixed step-size 0.3141. Default is 1.0.
-
-You can also make this independent of the size of the step `s`, by using
-`Static(scaled = true)`.
-This will then use a step-size alpha ← min(alpha,||s||_2) / ||s||_2
+`Static`: defines a static linesearch which returns the initial step length.
 """
-@with_kw struct Static{T}
-    alpha::T = 1.0
-    scaled::Bool = false # Scales step. alpha ← min(alpha,||s||_2) / ||s||_2
-end
+immutable Static end
 
 function (ls::Static)(df::AbstractObjective, x, s, α, x_new = similar(x), phi0 = nothing, dphi0 = nothing)
     ϕ = make_ϕ(df, x_new, x, s)
@@ -23,13 +13,6 @@ function (ls::Static)(df::AbstractObjective, x, s, α, x_new = similar(x), phi0 
 end
 
 function (ls::Static)(ϕ, x, s, alpha)
-    @unpack alpha, scaled = ls
-    @assert alpha > zero(typeof(alpha)) # This should really be done at the constructor level
-
-    if scaled == true && (ns = vecnorm(s)) > zero(typeof(alpha))
-        alpha = min(alpha, ns) / ns
-    end
-
     ϕα = ϕ(alpha)
 
     return alpha, ϕα

--- a/test/alphacalc.jl
+++ b/test/alphacalc.jl
@@ -7,8 +7,8 @@
     end
 
     @testset "Quadratic function" begin
-        lsalphas =     [1.0,   0.35355339059327373, 0.5, 0.5, 0.49995, 0.5,  0.5]  # types
-                        # Stat # Stat(scaled)       #HZ  wolfe   mt    bt2   bt3
+        lsalphas =     [1.0,   0.5, 0.5, 0.49995, 0.5,  0.5]  # types
+                        # Stat  #HZ  wolfe   mt    bt2   bt3
         x = [-1., -1.]
 
         for (i, linesearch!) in enumerate(lstypes)
@@ -70,8 +70,7 @@
         mayterminate = Ref{Bool}(false)
         alpha = 1.0; xtmp = zeros(x0)
 
-        lsalphas =  [1.0,                  # Static(scaled)
-                     0.021884405476620426, # Static(scaled)
+        lsalphas =  [1.0,                  # Static
                      0.01375274240750926,  # HZ
                      0.020646100006834013, # Wolfe
                      0.0175892025844326,   # MT

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ import NLSolversBase
 
 debug_printing = false
 
-lstypes =  (Static(), Static(scaled=true), HagerZhang(), StrongWolfe(), MoreThuente(),
+lstypes =  (Static(), HagerZhang(), StrongWolfe(), MoreThuente(),
             BackTracking(), BackTracking(order=2) )
 
 my_tests = [


### PR DESCRIPTION
This should remove the final barrier for us to fully univariatise the line searches.

The `scaled=true` feature can still be achieved by using `InitialStatic(scaled=true)` together with `Static()`