### PR TITLE
Change most zero(eltype(x)) usages to eltype(x)(0).

### DIFF
--- a/src/backtracking.jl
+++ b/src/backtracking.jl
@@ -96,7 +96,7 @@ function (ls::BackTracking)(ϕ, α_0::Tα, ϕ_0, dϕ_0) where Tα
                 α_tmp = dϕ_0 / (2*b)
             else
                 # discriminant
-                d = max(b^2 - 3*a*dϕ_0, zero(Tα))
+                d = max(b^2 - 3*a*dϕ_0, Tα(0))
                 # quadratic equation root
                 α_tmp = (-b + sqrt(d)) / (3*a)
             end

--- a/src/hagerzhang.jl
+++ b/src/hagerzhang.jl
@@ -125,7 +125,7 @@ function (ls::HagerZhang)(ϕ, ϕdϕ,
 
     (isfinite(phi_0) && isfinite(dphi_0)) || error("Initial value and slope must be finite")
     phi_lim = phi_0 + epsilon * abs(phi_0)
-    @assert c > zero(T)
+    @assert c > T(0)
     @assert isfinite(c) && c <= alphamax
     phi_c, dphi_c = ϕdϕ(c)
     iterfinite = 1
@@ -169,7 +169,7 @@ function (ls::HagerZhang)(ϕ, ϕdϕ,
                     ", phi_c = ", phi_c,
                     ", dphi_c = ", dphi_c)
         end
-        if dphi_c >= zero(T)
+        if dphi_c >= T(0)
             # We've reached the upward slope, so we have b; examine
             # previous values to find a
             ib = length(alphas)
@@ -185,7 +185,7 @@ function (ls::HagerZhang)(ϕ, ϕdϕ,
             # have crested over the peak. Use bisection.
             ib = length(alphas)
             ia = ib - 1
-            if c ≉  alphas[ib] || slopes[ib] >= zero(T)
+            if c ≉  alphas[ib] || slopes[ib] >= T(0)
                 error("c = ", c)
             end
             # ia, ib = bisect(phi, lsr, ia, ib, phi_lim) # TODO: Pass options
@@ -220,7 +220,7 @@ function (ls::HagerZhang)(ϕ, ϕdϕ,
             if !(isfinite(phi_c) && isfinite(dphi_c))
                 mayterminate[] = false # reset in case another initial guess is used next
                 return cold, ϕ(cold)
-            elseif dphi_c < zero(T) && c == alphamax
+            elseif dphi_c < T(0) && c == alphamax
                 # We're on the edge of the allowed region, and the
                 # value is still decreasing. This can be due to
                 # roundoff error in barrier penalties, a barrier
@@ -345,7 +345,8 @@ function secant2!(ϕdϕ,
     b = alphas[ib]
     dphi_a = slopes[ia]
     dphi_b = slopes[ib]
-    if !(dphi_a < zero(eltype(slopes)) && dphi_b >= zero(eltype(slopes)))
+    T = eltype(slopes)
+    if !(dphi_a < T(0) && dphi_b >= T(0))
         error(string("Search direction is not a direction of descent; ",
                      "this error may indicate that user-provided derivatives are inaccurate. ",
                       @sprintf "(dphi_a = %f; dphi_b = %f)" dphi_a dphi_b))
@@ -428,10 +429,11 @@ function update!(ϕdϕ,
                  display::Integer = 0)
     a = alphas[ia]
     b = alphas[ib]
+    T = eltype(slopes)
     # Debugging (HZ, eq. 4.4):
-    @assert slopes[ia] < zero(eltype(slopes))
+    @assert slopes[ia] < T(0)
     @assert values[ia] <= phi_lim
-    @assert slopes[ib] >= zero(eltype(slopes))
+    @assert slopes[ib] >= T(0)
     @assert b > a
     c = alphas[ic]
     phi_c = values[ic]
@@ -448,7 +450,7 @@ function update!(ϕdϕ,
     if c < a || c > b
         return ia, ib #, 0, 0  # it's out of the bracketing interval
     end
-    if dphi_c >= zero(eltype(slopes))
+    if dphi_c >= T(0)
         return ia, ic #, 0, 0  # replace b with a closer point
     end
     # We know dphi_c < 0. However, phi may not be monotonic between a
@@ -477,9 +479,9 @@ function bisect!(ϕdϕ,
     a = alphas[ia]
     b = alphas[ib]
     # Debugging (HZ, conditions shown following U3)
-    @assert slopes[ia] < zero(T)
+    @assert slopes[ia] < T(0)
     @assert values[ia] <= phi_lim
-    @assert slopes[ib] < zero(T)       # otherwise we wouldn't be here
+    @assert slopes[ib] < T(0)       # otherwise we wouldn't be here
     @assert values[ib] > phi_lim
     @assert b > a
     while b - a > eps(b)
@@ -495,7 +497,7 @@ function bisect!(ϕdϕ,
         push!(slopes, gphi)
 
         id = length(alphas)
-        if gphi >= zero(T)
+        if gphi >= T(0)
             return ia, id # replace b, return
         end
         if phi_d <= phi_lim

--- a/src/initialguess.jl
+++ b/src/initialguess.jl
@@ -14,7 +14,7 @@ end
 
 function (is::InitialStatic{T})(ls, state, phi_0, dphi_0, df) where T
     PT = promote_type(T, real(eltype(state.s)))
-    if is.scaled == true && (ns = real(vecnorm(state.s))) > zero(PT)
+    if is.scaled == true && (ns = real(vecnorm(state.s))) > PT(0)
         # TODO: Type instability if there's a type mismatch between is.alpha and ns?
         state.alpha = PT(min(is.alpha, ns)) / ns
     else
@@ -70,7 +70,7 @@ If αmax ≠ 1.0, then you should consider to ensure that snap2one[2] < αmax.
 end
 
 function (is::InitialQuadratic{T})(ls, state, phi_0, dphi_0, df) where T
-    if !isfinite(state.f_x_previous) || isapprox(dphi_0, zero(T), atol=eps(T)) # Need to add a tolerance
+    if !isfinite(state.f_x_previous) || isapprox(dphi_0, T(0), atol=eps(T)) # Need to add a tolerance
         # If we're at the first iteration
         αguess = is.α0
     else
@@ -113,7 +113,7 @@ If αmax ≠ 1.0, then you should consider to ensure that snap2one[2] < αmax.
 end
 
 function (is::InitialConstantChange{T})(ls, state, phi_0, dphi_0, df) where T
-    if !isfinite(state.dphi_0_previous) || !isfinite(state.alpha) || isapprox(dphi_0, zero(T), atol=eps(T))
+    if !isfinite(state.dphi_0_previous) || !isfinite(state.alpha) || isapprox(dphi_0, T(0), atol=eps(T))
         # If we're at the first iteration
         αguess = is.α0
     else
@@ -207,12 +207,12 @@ function _hzI12(alpha::T,
 
         iterfinite += 1
         if iterfinite >= iterfinitemax
-            return zero(T), true
+            return T(0), true
             #             error("Failed to achieve finite test value; alphatest = ", alphatest)
         end
     end
     a = ((phitest-phi_0)/alphatest - dphi_0)/alphatest  # quadratic fit
-    
+
     if verbose == true
         println("quadfit: alphatest = ", alphatest,
                 ", phi_0 = ", phi_0,
@@ -257,11 +257,11 @@ function _hzI0(x::AbstractArray{Tx},
                psi0::T = T(1)/100) where {Tx,T}
     alpha = one(T)
     gr_max = maximum(abs, gr)
-    if gr_max != zero(T)
+    if gr_max != T(0)
         x_max = maximum(abs, x)
-        if x_max != zero(T)
+        if x_max != T(0)
             alpha = psi0 * x_max / gr_max
-        elseif f_x != zero(T)
+        elseif f_x != T(0)
             alpha = psi0 * abs(f_x) / vecnorm(gr)
         end
     end

--- a/src/morethuente.jl
+++ b/src/morethuente.jl
@@ -168,12 +168,12 @@ function (ls::MoreThuente)(ϕdϕ,
     # Check the input parameters for errors.
     #
 
-    if  alpha <= zero(T) || f_tol < zero(T) || gtol < zero(T) ||
-        x_tol < zero(T) || alphamin < zero(T) || alphamax < alphamin || maxfev <= zero(T)
+    if  alpha <= T(0) || f_tol < T(0) || gtol < T(0) ||
+        x_tol < T(0) || alphamin < T(0) || alphamax < alphamin || maxfev <= T(0)
         throw(ArgumentError("Invalid parameters to morethuente"))
     end
 
-    if dϕ_0 >= zero(T)
+    if dϕ_0 >= T(0)
         throw(ArgumentError("Search direction is not a direction of descent"))
     end
 
@@ -201,10 +201,10 @@ function (ls::MoreThuente)(ϕdϕ,
     # function, and derivative at the current step.
     #
 
-    stx = zero(T)
+    stx = T(0)
     fx = finit
     dgx = dϕ_0
-    sty = zero(T)
+    sty = T(0)
     fy = finit
     dgy = dϕ_0
 
@@ -462,7 +462,7 @@ function cstep(stx::Real, fx::Real, dgx::Real,
    #
 
    if (bracketed && (alpha <= min(stx, sty) || alpha >= max(stx, sty))) ||
-     dgx * (alpha - stx) >= zero(T) || alphamax < alphamin
+     dgx * (alpha - stx) >= T(0) || alphamax < alphamin
        throw(ArgumentError("Minimizer not bracketed"))
    end
 
@@ -508,7 +508,7 @@ function cstep(stx::Real, fx::Real, dgx::Real,
    # the cubic step is taken, else the quadratic step is taken
    #
 
-   elseif sgnd < zero(T)
+elseif sgnd < T(0)
       info = 2
       bound = false
       theta = 3 * (fx - f) / (alpha - stx) + dgx + dg
@@ -561,7 +561,7 @@ function cstep(stx::Real, fx::Real, dgx::Real,
       p = gamma - dg + theta
       q = gamma + dgx - dg + gamma
       r = p / q
-      if r < zero(T) && gamma != zero(T)
+      if r < T(0) && gamma != T(0)
          alphac = alpha + r * (stx - alpha)
      elseif alpha > stx
          alphac = alphamax
@@ -624,7 +624,7 @@ function cstep(stx::Real, fx::Real, dgx::Real,
       fy = f
       dgy = dg
    else
-      if sgnd < zero(T)
+      if sgnd < T(0)
          sty = stx
          fy = fx
          dgy = dgx

--- a/src/strongwolfe.jl
+++ b/src/strongwolfe.jl
@@ -31,7 +31,7 @@ function (ls::StrongWolfe)(ϕ, dϕ, ϕdϕ,
     @unpack c_1, c_2, ρ = ls
 
     # Step-sizes
-    a_0 = zero(T)
+    a_0 = T(0)
     a_iminus1 = a_0
     a_i = alpha0
     a_max = T(65536)
@@ -66,7 +66,7 @@ function (ls::StrongWolfe)(ϕ, dϕ, ϕdϕ,
         end
 
         # Check condition 3
-        if dϕ_a_i >= zero(T) # FIXME untested!
+        if dϕ_a_i >= T(0) # FIXME untested!
             a_star = zoom(a_i, a_iminus1,
                           dϕ_0, ϕ_0, ϕ, dϕ, ϕdϕ)
             return a_star, ϕ(a_star)
@@ -139,7 +139,7 @@ function zoom(a_lo::T,
                 return a_j
             end
 
-            if ϕprime_a_j * (a_hi - a_lo) >= zero(T)
+            if ϕprime_a_j * (a_hi - a_lo) >= T(0)
                 a_hi = a_lo
             end
 


### PR DESCRIPTION
If `T` is a type `zero(T)` gives back a proper zero element. I think it's "prettier" to explicitly say "we want the number zero converted to this number type" by writing `T(0)`.