### PR TITLE
Don't filter example tests based on environment.

### DIFF
--- a/docs/generate.jl
+++ b/docs/generate.jl
@@ -1,14 +1,9 @@
 # generate examples
 import Literate
 
-# We shouldn't run the examples that require Optim in Travis/CI,
-# because an update in LineSearches may be breaking with the
-# most recently tagged Optim version.
-if get(ENV, "CI", "") == "true"
-    ONLYSTATIC = ["optim_linesearch.jl", "optim_initialstep.jl"]
-else
-    ONLYSTATIC = ["",]
-end
+# TODO: Remove items from `SKIPFILE` as soon as they run on the latest
+# stable `Optim` (or other dependency)
+ONLYSTATIC = ["optim_linesearch.jl", "optim_initialstep.jl"]
 
 EXAMPLEDIR = joinpath(@__DIR__, "src", "examples")
 GENERATEDDIR = joinpath(@__DIR__, "src", "examples", "generated")

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -1,12 +1,7 @@
 @testset "Literate examples" begin
-    # We shouldn't run the examples that require Optim in Travis/CI,
-    # because an update in LineSearches may be breaking with the
-    # most recently tagged Optim version.
-    if get(ENV, "CI", "") == "true"
-        SKIPFILE = ["optim_linesearch.jl", "optim_initialstep.jl"]
-    else
-        SKIPFILE = ["",]
-    end
+    # TODO: Remove items from `SKIPFILE` as soon as they run on the latest
+    # stable `Optim` (or other dependency)
+    SKIPFILE = ["optim_linesearch.jl", "optim_initialstep.jl"]
 
     EXAMPLEDIR = joinpath(@__DIR__, "../docs/src/examples")
 


### PR DESCRIPTION
Travis, AppVeyor, and CIBot all fail when there are breaking changes between LineSearches and downstream packages, such as Optim, that are also used in the examples.

I managed to filter on Travis and AppVeyor, but I don't know how to filter on CIBot. Instead of filtering tests based on CI environment, we'll just have to remember to add the tests back when the most recent downstream application works.