### PR TITLE
Fix \phi_0 and d\phi_0 values

### DIFF
--- a/src/backtracking.jl
+++ b/src/backtracking.jl
@@ -23,10 +23,10 @@ function (ls::BackTracking)(df::AbstractObjective, x::AbstractArray{T}, s::Abstr
     ϕ, dϕ = make_ϕ_dϕ(df, x_new, x, s)
 
     if ϕ_0 == nothing
-        ϕ_0 = ϕ(α_0)
+        ϕ_0 = ϕ(Tα(0))
     end
     if dϕ_0 == nothing
-        dϕ_0 = dϕ(α_0)
+        dϕ_0 = dϕ(Tα(0)))
     end
 
     α_0 = min(α_0, min(alphamax, ls.maxstep / vecnorm(s, Inf)))

--- a/src/backtracking.jl
+++ b/src/backtracking.jl
@@ -26,7 +26,7 @@ function (ls::BackTracking)(df::AbstractObjective, x::AbstractArray{T}, s::Abstr
         ϕ_0 = ϕ(Tα(0))
     end
     if dϕ_0 == nothing
-        dϕ_0 = dϕ(Tα(0)))
+        dϕ_0 = dϕ(Tα(0))
     end
 
     α_0 = min(α_0, min(alphamax, ls.maxstep / vecnorm(s, Inf)))

--- a/src/hagerzhang.jl
+++ b/src/hagerzhang.jl
@@ -109,8 +109,12 @@ function (ls::HagerZhang)(ϕ, ϕdϕ,
     @unpack delta, sigma, alphamax, rho, epsilon, gamma,
             linesearchmax, psi3, display, mayterminate = ls
 
-    if dphi_0 == T(0)
-        return T(0), phi_0
+
+    if !(isfinite(phi_0) && isfinite(dphi_0))
+        throw(ArgumentError("Value and slope at step length = 0 must be finite."))
+    end
+    if dphi_0 >= T(0)
+        throw(ArgumentError("Search direction is not a direction of descent."))
     end
 
     # Prevent values of x_new = x+αs that are likely to make
@@ -123,7 +127,7 @@ function (ls::HagerZhang)(ϕ, ϕdϕ,
         println("New linesearch")
     end
 
-    (isfinite(phi_0) && isfinite(dphi_0)) || error("Initial value and slope must be finite")
+
     phi_lim = phi_0 + epsilon * abs(phi_0)
     @assert c > T(0)
     @assert isfinite(c) && c <= alphamax

--- a/src/hagerzhang.jl
+++ b/src/hagerzhang.jl
@@ -95,8 +95,8 @@ end
 HagerZhang{T}(args...; kwargs...) where T = HagerZhang{T, Base.RefValue{Bool}}(args...; kwargs...)
 
 function (ls::HagerZhang)(df::AbstractObjective, x::AbstractArray{T},
-                            s::AbstractArray{T}, α::Real,
-                            x_new::AbstractArray{T}, phi_0::Real, dphi_0::Real) where T
+                          s::AbstractArray{T}, α::Real,
+                          x_new::AbstractArray{T}, phi_0::Real, dphi_0::Real) where T
     ϕ, ϕdϕ = make_ϕ_ϕdϕ(df, x_new, x, s)
     ls(ϕ, ϕdϕ, α::Real, phi_0, dphi_0)
 end
@@ -110,7 +110,7 @@ function (ls::HagerZhang)(ϕ, ϕdϕ,
             linesearchmax, psi3, display, mayterminate = ls
 
     if dphi_0 == T(0)
-        return c, phi_0
+        return T(0), phi_0
     end
 
     # Prevent values of x_new = x+αs that are likely to make

--- a/src/morethuente.jl
+++ b/src/morethuente.jl
@@ -159,10 +159,6 @@ function (ls::MoreThuente)(ϕdϕ,
                   dϕ_0) where T
     @unpack f_tol, gtol, x_tol, alphamin, alphamax, maxfev = ls
 
-    if dϕ_0 == T(0)
-        return T(0), ϕ_0
-    end
-
     iterfinitemax = -log2(eps(T))
     info = 0
     info_cstep = 1 # Info from step
@@ -173,11 +169,11 @@ function (ls::MoreThuente)(ϕdϕ,
 
     if  alpha <= T(0) || f_tol < T(0) || gtol < T(0) ||
         x_tol < T(0) || alphamin < T(0) || alphamax < alphamin || maxfev <= T(0)
-        throw(ArgumentError("Invalid parameters to morethuente"))
+        throw(ArgumentError("Invalid parameters to MoreThuente."))
     end
 
     if dϕ_0 >= T(0)
-        throw(ArgumentError("Search direction is not a direction of descent"))
+        throw(ArgumentError("Search direction is not a direction of descent."))
     end
 
     #

--- a/src/morethuente.jl
+++ b/src/morethuente.jl
@@ -150,8 +150,6 @@ end
 function (ls::MoreThuente)(df::AbstractObjective, x::AbstractArray{T},
                            s::AbstractArray{T}, alpha::Real, x_new::AbstractArray{T},
                            ϕ_0, dϕ_0) where T
-
-
     ϕdϕ = make_ϕdϕ(df, x_new, x, s)
     ls(ϕdϕ, alpha, ϕ_0, dϕ_0)
 end
@@ -162,7 +160,7 @@ function (ls::MoreThuente)(ϕdϕ,
     @unpack f_tol, gtol, x_tol, alphamin, alphamax, maxfev = ls
 
     if dϕ_0 == T(0)
-        return alpha, ϕ_0
+        return T(0), ϕ_0
     end
 
     iterfinitemax = -log2(eps(T))

--- a/test/alphacalc.jl
+++ b/test/alphacalc.jl
@@ -50,8 +50,20 @@
                 linesearch!.mayterminate[] = false
             end
 
-            alpha, ϕalpha = linesearch!(df, x, p, alpha, xtmp, phi_0, dphi_0)
-            @test alpha == 1.0 # Is this what we want for non-descent directions?
+            if typeof(linesearch!) <: Union{HagerZhang, MoreThuente}
+                @test_throws ArgumentError linesearch!(df, x, p, alpha,
+                                                       xtmp, phi_0, dphi_0)
+                try
+                    linesearch!(df, x, p, alpha,
+                                xtmp, phi_0, dphi_0)
+                catch ex
+                    @test ex.msg == "Search direction is not a direction of descent."
+                end
+            else
+                α, ϕα = linesearch!(df, x, p, alpha, xtmp, phi_0, dphi_0)
+                @test ϕα == phi_0
+                @test alpha == α # Is this what we want zero-slope directions?
+            end
         end
     end
 


### PR DESCRIPTION
The values of ϕ_0 and dϕ_0 are ϕ(0), dϕ(0), not ϕ(\alpha_0)).

It is a bit confusing to use α_0  as the initial guess, because it means that we think ϕ_0 refers to the value at the initial guess. Maybe we should change all α0 / α_0's to αinitial?