### PR TITLE
Updates for Julia 0.7-beta

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7-beta
 NLSolversBase 5.0
 Parameters
 NaNMath

--- a/docs/src/examples/customoptimizer.jl
+++ b/docs/src/examples/customoptimizer.jl
@@ -28,11 +28,11 @@ function gdoptimize(f, g!, fg!, x0::AbstractArray{T}, linesearch,
     ϕ(α) = f(x .+ α.*s)
     function dϕ(α)
         g!(gvec, x .+ α.*s)
-        return vecdot(gvec, s)
+        return dot(gvec, s)
     end
     function ϕdϕ(α)
         phi = fg!(gvec, x .+ α.*s)
-        dphi = vecdot(gvec, s)
+        dphi = dot(gvec, s)
         return (phi, dphi)
     end
 
@@ -100,7 +100,7 @@ ls = BackTracking(order=3)
 fx_bt3, x_bt3, iter_bt3 = gdoptimize(f, g!, fg!, x0, ls)
 
 ## Test the results                #src
-using Base.Test                    #src
+using Test                         #src
 @test fx_bt3 < 1e-12               #src
 @test iter_bt3 < 10000             #src
 @test x_bt3 ≈ [1.0, 1.0] atol=1e-7 #src

--- a/docs/src/examples/optim_initialstep.jl
+++ b/docs/src/examples/optim_initialstep.jl
@@ -34,7 +34,7 @@ res_hz = Optim.optimize(prob.f, prob.g!, prob.h!, prob.initial_x, method=algo_hz
 # From the result we see that this has reduced the number of function and gradient calls, but increased the number of iterations.
 
 ## Test the results                                       #src
-using Base.Test                                           #src
+using Test                                                #src
 @test Optim.f_calls(res_hz) < Optim.f_calls(res_st)       #src
 @test Optim.g_calls(res_hz) < Optim.g_calls(res_st)       #src
 @test Optim.iterations(res_hz) > Optim.iterations(res_st) #src

--- a/docs/src/examples/optim_linesearch.jl
+++ b/docs/src/examples/optim_linesearch.jl
@@ -33,6 +33,6 @@ res_bt3 = Optim.optimize(prob.f, prob.g!, prob.h!, prob.initial_x, method=algo_b
 
 
 ## Test the results                                #src
-using Base.Test                                    #src
+using Test                                           #src
 @test Optim.f_calls(res_bt3) < Optim.f_calls(res_hz) #src
 @test Optim.g_calls(res_bt3) < Optim.g_calls(res_hz) #src

--- a/src/LineSearches.jl
+++ b/src/LineSearches.jl
@@ -1,11 +1,12 @@
-isdefined(Base, :__precompile__) && __precompile__()
+__precompile__()
+
 
 module LineSearches
 
 using   Compat,
         Compat.LinearAlgebra,
         Compat.Distributed,
-        Compat.Printf
+        Printf
 
 using Parameters, NaNMath
 
@@ -38,7 +39,7 @@ function make_ϕdϕ(df, x_new, x, s)
         NLSolversBase.value_gradient!(df, x_new)
 
         # Calculate ϕ(a_i), ϕ'(a_i)
-        NLSolversBase.value(df), real(vecdot(NLSolversBase.gradient(df), s))
+        NLSolversBase.value(df), real(dot(NLSolversBase.gradient(df), s))
     end
     ϕdϕ
 end
@@ -51,7 +52,7 @@ function make_ϕ_dϕ(df, x_new, x, s)
         NLSolversBase.gradient!(df, x_new)
 
         # Calculate ϕ'(a_i)
-        real(vecdot(NLSolversBase.gradient(df), s))
+        real(dot(NLSolversBase.gradient(df), s))
     end
     make_ϕ(df, x_new, x, s), dϕ
 end
@@ -64,7 +65,7 @@ function make_ϕ_dϕ_ϕdϕ(df, x_new, x, s)
         NLSolversBase.gradient!(df, x_new)
 
         # Calculate ϕ'(a_i)
-        real(vecdot(NLSolversBase.gradient(df), s))
+        real(dot(NLSolversBase.gradient(df), s))
     end
     function ϕdϕ(α)
         # Move a distance of alpha in the direction of s
@@ -74,7 +75,7 @@ function make_ϕ_dϕ_ϕdϕ(df, x_new, x, s)
         NLSolversBase.value_gradient!(df, x_new)
 
         # Calculate ϕ'(a_i)
-        NLSolversBase.value(df), real(vecdot(NLSolversBase.gradient(df), s))
+        NLSolversBase.value(df), real(dot(NLSolversBase.gradient(df), s))
     end
     make_ϕ(df, x_new, x, s), dϕ, ϕdϕ
 end
@@ -87,7 +88,7 @@ function make_ϕ_ϕdϕ(df, x_new, x, s)
         NLSolversBase.value_gradient!(df, x_new)
 
         # Calculate ϕ'(a_i)
-        NLSolversBase.value(df), real(vecdot(NLSolversBase.gradient(df), s))
+        NLSolversBase.value(df), real(dot(NLSolversBase.gradient(df), s))
     end
     make_ϕ(df, x_new, x, s), ϕdϕ
 end

--- a/src/backtracking.jl
+++ b/src/backtracking.jl
@@ -29,7 +29,7 @@ function (ls::BackTracking)(df::AbstractObjective, x::AbstractArray{T}, s::Abstr
         dϕ_0 = dϕ(Tα(0))
     end
 
-    α_0 = min(α_0, min(alphamax, ls.maxstep / vecnorm(s, Inf)))
+    α_0 = min(α_0, min(alphamax, ls.maxstep / norm(s, Inf)))
     ls(ϕ, α_0, ϕ_0, dϕ_0)
 end
 

--- a/src/initialguess.jl
+++ b/src/initialguess.jl
@@ -14,7 +14,7 @@ end
 
 function (is::InitialStatic{T})(ls, state, phi_0, dphi_0, df) where T
     PT = promote_type(T, real(eltype(state.s)))
-    if is.scaled == true && (ns = real(vecnorm(state.s))) > PT(0)
+    if is.scaled == true && (ns = real(norm(state.s))) > PT(0)
         # TODO: Type instability if there's a type mismatch between is.alpha and ns?
         state.alpha = PT(min(is.alpha, ns)) / ns
     else
@@ -89,7 +89,7 @@ end
 Constant first-order change approximation to determine initial step length.
 
 ** This requires that the optimization algorithm stores dphi0 from the previous iteration **
-(dphi0_previous = real(vecdot(∇f_{k-1}, s_{k-1})), where s is the step direction.
+(dphi0_previous = real(dot(∇f_{k-1}, s_{k-1})), where s is the step direction.
 
 This is meant for methods that do not produce well-scaled search directions,
 such as Gradient Descent and (variations of) Conjugate Gradient methods.

--- a/src/static.jl
+++ b/src/static.jl
@@ -71,7 +71,7 @@ end
 
 `NewStatic` is intended for methods with well-scaled updates; i.e. Newton, on well-behaved problems.
 """
-immutable NewStatic end
+struct NewStatic end
 
 function (ls::NewStatic)(df::AbstractObjective, x, s, α, x_new = similar(x), ϕ_0 = nothing, dϕ_0 = nothing)
     ϕ = make_ϕ(df, x_new, x, s)

--- a/src/strongwolfe.jl
+++ b/src/strongwolfe.jl
@@ -40,7 +40,7 @@ function (ls::StrongWolfe)(ϕ, dϕ, ϕdϕ,
     ϕ_a_iminus1 = ϕ_0
     ϕ_a_i = T(NaN)
 
-    # ϕ'(alpha) = vecdot(g(x + alpha * p), p)
+    # ϕ'(alpha) = dot(g(x + alpha * p), p)
     dϕ_a_i = T(NaN)
 
     # Iteration counter

--- a/test/alphacalc.jl
+++ b/test/alphacalc.jl
@@ -1,7 +1,7 @@
 @testset "alpha-calculations" begin
     import NLSolversBase
 
-    f(x) = vecdot(x, x)
+    f(x) = dot(x, x)
     function g!(out, x)
         out[:] = 2x
     end
@@ -76,7 +76,7 @@
         s = [42.0,18.0]
 
         mayterminate = Ref{Bool}(false)
-        alpha = 1.0; xtmp = zeros(x0)
+        alpha = 1.0; xtmp = zero(x0)
 
         lsalphas =  [1.0,                  # Static
                      0.01375274240750926,  # HZ

--- a/test/arbitrary_precision.jl
+++ b/test/arbitrary_precision.jl
@@ -1,7 +1,7 @@
 for T in [Float32, Float64, typeof(DoubleFloat64(1)), BigFloat]
     @eval begin
         @testset "Arbitrary precision - initial step guess: $($T)" begin
-            f(x) = vecdot(x, x)
+            f(x) = dot(x, x)
             function g!(out, x)
                 out[:] = 2x
             end

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -8,7 +8,7 @@
 
     EXAMPLEDIR = joinpath(@__DIR__, "../docs/src/examples")
 
-    myfilter(str) = r"\.jl$"(str) && !(str in SKIPFILE)
+    myfilter(str) = occursin(r"\.jl$", str) && !(str in SKIPFILE)
     for file in filter!(myfilter, readdir(EXAMPLEDIR))
         @testset "$file" begin
             mktempdir() do dir

--- a/test/initial.jl
+++ b/test/initial.jl
@@ -1,5 +1,5 @@
 @testset "Initial step guess" begin
-    f(x) = vecdot(x, x)
+    f(x) = dot(x, x)
     function g!(out, x)
         out[:] = 2x
     end
@@ -48,7 +48,7 @@
     state = getstate()
     is = InitialStatic(alpha = 0.5, scaled = true)
     is(ls, state, phi_0, dphi_0, df)
-    @test state.alpha == 0.5 / vecnorm(state.s)
+    @test state.alpha == 0.5 / norm(state.s)
     @test ls.mayterminate[] == false
     is = InitialStatic(alpha = 0.5, scaled = true)
     state.s .= (is.alpha / 100)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using LineSearches
 using   Compat,
-        Compat.Test,
+        Test,
         Compat.LinearAlgebra
 using OptimTestProblems
 using HigherPrecision


### PR DESCRIPTION
I've had a go at updating LineSearches for Julia 0.7-beta. Mostly it's replacing `vecdot` with `dot` and `vecnorm` with `norm` since they are now equivalent as far as I can tell from the deprecation messages and docstrings. There are a few other changes but nothing major.

As far as I can tell the tests pass except for the ones that depend on external packages that haven't been updated (e.g., Optim and HigherPrecision).