### PR TITLE
Changed Julia to v1.6 and NaNMath to v1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LineSearches"
 uuid = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
-version = "7.1.1"
+version = "7.1.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 [compat]
 DoubleFloats = "1"
 NLSolversBase = "7"
-NaNMath = "0.3"
+NaNMath = "1"
 Parameters = "0.10, 0.11, 0.12"
 julia = "1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ DoubleFloats = "1"
 NLSolversBase = "7"
 NaNMath = "0.3"
 Parameters = "0.10, 0.11, 0.12"
-julia = "1"
+julia = "1.6"
 
 [extras]
 DoubleFloats = "497a8b3b-efae-58df-a0af-a86822472b78"


### PR DESCRIPTION
Updating just NaNMath to v1 causes build failure for Julia v1. Since 1.6 is now the LTS version, make sense to up the version requirement for LineSearches as well.