### PR TITLE
Add LineSearchTestCase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 docs/build
 docs/src/examples/generated
 /docs/Manifest.toml
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,8 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 DoubleFloats = "1"
 NLSolversBase = "7"
 NaNMath = "1"
+Optim = "1"
+OptimTestProblems = "2"
 Parameters = "0.10, 0.11, 0.12"
 julia = "1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LineSearches"
 uuid = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
-version = "7.2.0"
+version = "7.3.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -46,6 +46,14 @@ using LineSearches
 ```
 to load the package.
 
+## Debugging
+
+If you suspect a method of suboptimal performance or find that your code errors,
+create a [`LineSearchCache`](@ref) to record intermediate values for later
+inspection and analysis. If you're using this via Optim.jl, configure it inside
+the method, e.g., `Newton(linesearch=LineSearches.MoreThuente(; cache))`. The
+value stored in the cache will reflect the final iteration of line search during
+optimization.
 
 ## References
 

--- a/docs/src/reference/linesearch.md
+++ b/docs/src/reference/linesearch.md
@@ -11,3 +11,9 @@ MoreThuente
 Static
 StrongWolfe
 ```
+
+## Debugging
+
+```@docs
+LineSearchCache
+```

--- a/src/LineSearches.jl
+++ b/src/LineSearches.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module LineSearches
 
 using Printf
@@ -9,12 +7,13 @@ using Parameters, NaNMath
 import NLSolversBase
 import NLSolversBase: AbstractObjective
 
-export LineSearchException
+export LineSearchException, LineSearchCache
 
-export BackTracking, HagerZhang, Static, MoreThuente, StrongWolfe
+export AbstractLineSearch, BackTracking, HagerZhang, Static, MoreThuente, StrongWolfe
 
 export InitialHagerZhang, InitialStatic, InitialPrevious,
     InitialQuadratic, InitialConstantChange
+
 
 function make_ϕ(df, x_new, x, s)
     function ϕ(α)
@@ -90,6 +89,26 @@ function make_ϕ_ϕdϕ(df, x_new, x, s)
 end
 
 include("types.jl")
+
+# The following don't extend `empty!` and `push!` because we want implementations for `nothing`
+# and that would be piracy
+emptycache!(cache::LineSearchCache) = begin
+    empty!(cache.alphas)
+    empty!(cache.values)
+    empty!(cache.slopes)
+end
+emptycache!(::Nothing) = nothing
+pushcache!(cache::LineSearchCache, α, val, slope) = begin
+    push!(cache.alphas, α)
+    push!(cache.values, val)
+    push!(cache.slopes, slope)
+end
+pushcache!(cache::LineSearchCache, α, val) = begin
+    push!(cache.alphas, α)
+    push!(cache.values, val)
+end
+pushcache!(::Nothing, α, val, slope) = nothing
+pushcache!(::Nothing, α, val) = nothing
 
 # Line Search Methods
 include("backtracking.jl")

--- a/src/hagerzhang.jl
+++ b/src/hagerzhang.jl
@@ -128,7 +128,7 @@ function (ls::HagerZhang)(ϕ, ϕdϕ,
     # ϕ(x_new) infinite
     iterfinitemax::Int = ceil(Int, -log2(eps(T)))
     if cache !== nothing
-        @unpack alphas, value, slopes = cache
+        @unpack alphas, values, slopes = cache
     else
         alphas = [zeroT] # for bisection
         values = [phi_0]

--- a/src/static.jl
+++ b/src/static.jl
@@ -3,7 +3,7 @@
 
 `Static` is intended for methods with well-scaled updates; i.e. Newton, on well-behaved problems.
 """
-struct Static end
+struct Static <: AbstractLineSearch end
 
 function (ls::Static)(df::AbstractObjective, x, s, α, x_new = similar(x), ϕ_0 = nothing, dϕ_0 = nothing)
     ϕ = make_ϕ(df, x_new, x, s)

--- a/src/types.jl
+++ b/src/types.jl
@@ -2,3 +2,39 @@ mutable struct LineSearchException{T<:Real} <: Exception
     message::AbstractString
     alpha::T
 end
+
+abstract type AbstractLineSearch end
+
+# For debugging
+struct LineSearchCache{T}
+    alphas::Vector{T}
+    values::Vector{T}
+    slopes::Vector{T}
+end
+"""
+    cache = LineSearchCache{T}()
+
+Initialize an empty cache for storing intermediate results during line search.
+The `α`, `ϕ(α)`, and possibly `dϕ(α)` values computed during line search are
+available in `cache.alphas`, `cache.values`, and `cache.slopes`, respectively.
+
+# Example
+
+```jldoctest
+julia> ϕ(x) = (x - π)^4; dϕ(x) = 4*(x-π)^3;
+
+julia> cache = LineSearchCache{Float64}();
+
+julia> ls = BackTracking(; cache);
+
+julia> ls(ϕ, 10.0, ϕ(0), dϕ(0))
+(1.8481462933284658, 2.7989406670901373)
+
+julia> cache
+LineSearchCache{Float64}([0.0, 10.0, 1.8481462933284658], [97.40909103400242, 2212.550050116452, 2.7989406670901373], [-124.02510672119926])
+```
+
+Because `BackTracking` doesn't use derivatives except at `α=0`, only the initial slope was stored in the cache.
+Other methods may store all three.
+"""
+LineSearchCache{T}() where T = LineSearchCache{T}(T[], T[], T[])

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,0 @@
-OptimTestProblems
-DoubleFloats 0.1.10
-Optim 0.16

--- a/test/TestCases.jl
+++ b/test/TestCases.jl
@@ -1,0 +1,67 @@
+module TestCases
+
+# A module for reproducing simplified versions of objective functions that cause trouble for line search methods
+
+using NLSolversBase
+
+export LineSearchTestCase
+
+struct LineSearchTestCase
+    alphas::Vector{Float64}
+    values::Vector{Float64}
+    slopes::Vector{Float64}
+
+    function LineSearchTestCase(alphas, values, slopes)
+        Base.require_one_based_indexing(alphas, values, slopes)
+        n = length(alphas)
+        if n != length(values) || n != length(slopes)
+            throw(ArgumentError("Lengths of alphas, values, and slopes must match"))
+        end
+        perm = sortperm(alphas)
+        alphas, values, slopes = alphas[perm], values[perm], slopes[perm]
+        # For interpolation, add a dummy value at the end
+        push!(alphas, alphas[end]+1)
+        push!(values, values[end])
+        push!(slopes, 0.0)
+        return new(alphas, values, slopes)
+    end
+end
+
+Base.minimum(tc::LineSearchTestCase) = minimum(tc.values)
+
+function NLSolversBase.OnceDifferentiable(tc::LineSearchTestCase)
+    function fdf(x)
+        x < zero(x) && throw(ArgumentError("x must be nonnegative, got $x"))
+        i = findfirst(>(x), tc.alphas)
+        (i === nothing || x > tc.alphas[end-1]) && throw(ArgumentError("x must be <=$(tc.alphas[end-1]), got $x"))
+        i -= 1
+        xk = tc.alphas[i]
+        xkp1 = tc.alphas[i + 1]
+        dx = xkp1 - xk
+        t = (x - xk) / dx
+        h00t = 2t^3 - 3t^2 + 1
+        h10t = t * (1 - t)^2
+        h01t = t^2 * (3 - 2t)
+        h11t = t^2 * (t - 1)
+        val =
+            h00t * tc.values[i] +
+            h10t * dx * tc.slopes[i] +
+            h01t * tc.values[i + 1] +
+            h11t * dx * tc.slopes[i + 1]
+        h00tp = 6t^2 - 6t
+        h10tp = 3t^2 - 4t + 1
+        h01tp = -6t^2 + 6 * t
+        h11tp = 3t^2 - 2t
+        slope =
+            (
+                h00tp * tc.values[i] +
+                h10tp * dx * tc.slopes[i] +
+                h01tp * tc.values[i + 1] +
+                h11tp * dx * tc.slopes[i + 1]
+            ) / dx
+        return val, slope
+    end
+    return OnceDifferentiable(α -> fdf(α)[1], α -> fdf(α)[2], fdf, [0.0])
+end
+
+end

--- a/test/TestCases.jl
+++ b/test/TestCases.jl
@@ -17,7 +17,15 @@ struct LineSearchTestCase
         if n != length(values) || n != length(slopes)
             throw(ArgumentError("Lengths of alphas, values, and slopes must match"))
         end
+        # Ensure ordered & unique
         perm = sortperm(alphas)
+        delidx = Int[]
+        for i in firstindex(perm)+1:lastindex(perm)
+            if alphas[perm[i]] == alphas[perm[i-1]]
+                push!(delidx, i)
+            end
+        end
+        deleteat!(perm, delidx)
         alphas, values, slopes = alphas[perm], values[perm], slopes[perm]
         # For interpolation, add a dummy value at the end
         push!(alphas, alphas[end]+1)

--- a/test/captured.jl
+++ b/test/captured.jl
@@ -1,0 +1,21 @@
+using LineSearches
+using NLSolversBase
+using Test
+
+if !isdefined(@__MODULE__, :LineSearchTestCase)
+    include("TestCases.jl")
+    using .TestCases
+end
+
+# From PR#174
+@testset "PR#174" begin
+    tc = LineSearchTestCase(
+        [0.0, 1.0, 5.0, 3.541670844449739],
+        [3003.592409634743, 2962.0378569864743, 2891.4462095232184, 3000.9760725116876],
+        [-22332.321416890798, -20423.214551925797, 11718.185026267562, -22286.821227217057]
+    )
+    fdf = OnceDifferentiable(tc)
+    hz = HagerZhang()
+    α, val = hz(fdf.f, fdf.fdf, 1.0, fdf.fdf(0.0)...)
+    @test_broken val <= minimum(tc)
+end

--- a/test/captured.jl
+++ b/test/captured.jl
@@ -7,6 +7,20 @@ if !isdefined(@__MODULE__, :LineSearchTestCase)
     using .TestCases
 end
 
+@testset "Capturing data" begin
+    cache = LineSearchCache{Float64}()
+    lsalgs =  (HagerZhang(; cache), StrongWolfe(; cache), MoreThuente(; cache),
+               BackTracking(; cache), BackTracking(; order=2, cache) )
+    ϕ(x) = (x - π)^4
+    dϕ(x) = 4*(x-π)^3
+    ϕdϕ(x) = (ϕ(x), dϕ(x))
+    for ls in lsalgs
+        α, val = ls(ϕ, dϕ, ϕdϕ, 10.0, ϕ(0), dϕ(0))
+        @test α < 10
+        @test length(cache.alphas) == length(cache.values) && length(cache.alphas) > 1
+    end
+end
+
 # From PR#174
 @testset "PR#174" begin
     tc = LineSearchTestCase(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,8 @@ my_tests = [
     "initial.jl",
     "alphacalc.jl",
     "arbitrary_precision.jl",
-    "examples.jl"
+    "examples.jl",
+    "captured.jl"
 ]
 
 mutable struct StateDummy


### PR DESCRIPTION
Also includes the failing case in PR#174.

This is minimally modified from the code provided by @mateuszbaran (who I've listed as a co-author).

~~One thing that seems missing: documentation on how to capture the specific values tried by the failing line search method. I'm not broadly familiar with them all, is there any good guidance on that? Or should we add a `cache::Bool` option to them all?~~

Once this gets merged, we should first capture any other problem reports and then start trying to fix the failures.

Closes #102
