### PR TITLE
Fix sign error and cancellation in BackTracking cubic interpolation

### DIFF
--- a/src/backtracking.jl
+++ b/src/backtracking.jl
@@ -24,10 +24,10 @@ function (ls::BackTracking)(df::AbstractObjective, x::AbstractArray{T}, s::Abstr
     ϕ, dϕ = make_ϕ_dϕ(df, x_new, x, s)
 
     if ϕ_0 == nothing
-        ϕ_0 = ϕ(Tα(0))
+        ϕ_0 = ϕ(zero(Tα))
     end
     if dϕ_0 == nothing
-        dϕ_0 = dϕ(Tα(0))
+        dϕ_0 = dϕ(zero(Tα))
     end
 
     α_0 = min(α_0, min(alphamax, ls.maxstep / norm(s, Inf)))
@@ -104,7 +104,7 @@ function (ls::BackTracking)(ϕ, αinitial::Tα, ϕ_0, dϕ_0) where Tα
                 α_tmp = -dϕ_0 / (2*b)
             else
                 # discriminant
-                d = max(b^2 - 3*a*dϕ_0, Tα(0))
+                d = max(b^2 - 3*a*dϕ_0, zero(Tα))
                 # quadratic equation root, rewritten via the conjugate to avoid
                 # catastrophic cancellation when -b and sqrt(d) are close
                 α_tmp = -dϕ_0 / (b + sqrt(d))

--- a/src/backtracking.jl
+++ b/src/backtracking.jl
@@ -101,12 +101,13 @@ function (ls::BackTracking)(ϕ, αinitial::Tα, ϕ_0, dϕ_0) where Tα
             b = (-α_1^3*(ϕx_1 - ϕ_0 - dϕ_0*α_2) + α_2^3*(ϕx_0 - ϕ_0 - dϕ_0*α_1))*div
 
             if isapprox(a, zero(a), atol=eps(real(Tα)))
-                α_tmp = dϕ_0 / (2*b)
+                α_tmp = -dϕ_0 / (2*b)
             else
                 # discriminant
                 d = max(b^2 - 3*a*dϕ_0, Tα(0))
-                # quadratic equation root
-                α_tmp = (-b + sqrt(d)) / (3*a)
+                # quadratic equation root, rewritten via the conjugate to avoid
+                # catastrophic cancellation when -b and sqrt(d) are close
+                α_tmp = -dϕ_0 / (b + sqrt(d))
             end
         end
 

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -171,6 +171,32 @@ res = (StrongWolfe())(ϕ, dϕ, ϕdϕ, α0, ϕ0, dϕ0)
     end
     =#
 
+    @testset "BackTracking cubic interpolation (PR #172)" begin
+        # Regression test for the cubic-interpolation branch of BackTracking:
+        #   1. degenerate (a ≈ 0) case used the wrong sign for α_tmp;
+        #   2. general case used (-b + √Δ)/(3a), which loses precision to
+        #      catastrophic cancellation when b > 0 and dϕ_0 < 0.
+        # Repro from @AlexandreMagueresse in PR #172.
+        ϕ(x) = -sin(x) / x
+        dϕ(x) = -(cos(x) * x - sin(x)) / x^2
+        ϕdϕ(x) = ϕ(x), dϕ(x)
+
+        α0 = 1.0f5
+        x0 = -3.0
+        ϕ0, dϕ0 = ϕ(x0), dϕ(x0)
+
+        α, val = BackTracking()(ϕ, dϕ, ϕdϕ, α0, ϕ0, dϕ0)
+
+        # Sufficient decrease must hold for any valid BackTracking result.
+        c_1 = 1e-4
+        @test val ≤ ϕ0 + c_1 * α * dϕ0
+
+        # The buggy code returned α ≈ 8.43 with ϕ ≈ -0.0993; the fixed cubic
+        # interpolation lands at α ≈ 2.18 with ϕ ≈ -0.374, a meaningfully
+        # better minimizer along the descent direction.
+        @test val < -0.2
+    end
+
     @testset "Interior NaN within finite bracket" begin
         # φ is finite on [0, 1] ∪ [3, ∞) and non-finite on (1, 3). A standard
         # expansion brackets with ia at α=1 (finite, dφ<0) and ib at α=5


### PR DESCRIPTION
Implements #172 so sorry for not following it all the way to the door sooner @AlexandreMagueresse

The cubic-interpolation branch of BackTracking had two bugs:

1. In the degenerate (a ≈ 0) case, α_tmp = dϕ_0 / (2*b) was missing a minus sign — the minimizer of the resulting quadratic is -ϕ'(0) / (2b), not +ϕ'(0) / (2b).

2. In the general case, the Nocedal-Wright root expression (-b + √(b² − 3aϕ'(0))) / (3a) suffers catastrophic cancellation when ϕ'(0) < 0 and b > 0 (the discriminant exceeds b², so √Δ approaches |b| and the numerator is a difference of close positives). Rewriting via the conjugate as -ϕ'(0)/(b + √Δ) avoids the cancellation and reduces cleanly to the degenerate form as a → 0.

Adds a regression test using the example provided by Alexandre in PR #172 (ϕ(x) = -sin(x)/x, α₀ = 1e5, x₀ = -3): the old code lands at α ≈ 8.43, the fix at α ≈ 2.18, a meaningfully better minimizer.