### PR TITLE
Fix StrongWolfe ignoring c_1/c_2, and cut redundant objective evaluations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LineSearches"
 uuid = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
-version = "7.7.1"
+version = "7.7.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/LineSearches.jl
+++ b/src/LineSearches.jl
@@ -45,9 +45,6 @@ end
 function make_ϕ_dϕ_ϕdϕ(df, x_new, x, s)
     make_ϕ_dϕ(df, x_new, x, s)..., make_ϕdϕ(df, x_new, x, s)
 end
-function make_ϕ_ϕdϕ(df, x_new, x, s)
-    make_ϕ(df, x_new, x, s), make_ϕdϕ(df, x_new, x, s)
-end
 
 include("types.jl")
 

--- a/src/backtracking.jl
+++ b/src/backtracking.jl
@@ -23,12 +23,13 @@ BackTracking{TF}(args...; kwargs...) where TF = BackTracking{TF,Int}(args...; kw
 
 function (ls::BackTracking)(df::AbstractObjective, x::AbstractArray{T}, s::AbstractArray{T},
                             α_0::Tα = real(T)(1), x_new::AbstractArray{T} = similar(x), ϕ_0 = nothing, dϕ_0 = nothing, alphamax = typemax(real(T))) where {T, Tα}
-    ϕ, dϕ = make_ϕ_dϕ(df, x_new, x, s)
+    ϕ, dϕ, ϕdϕ = make_ϕ_dϕ_ϕdϕ(df, x_new, x, s)
 
-    if isnothing(ϕ_0)
+    if isnothing(ϕ_0) && isnothing(dϕ_0)
+        ϕ_0, dϕ_0 = ϕdϕ(zero(Tα))
+    elseif isnothing(ϕ_0)
         ϕ_0 = ϕ(zero(Tα))
-    end
-    if isnothing(dϕ_0)
+    elseif isnothing(dϕ_0)
         dϕ_0 = dϕ(zero(Tα))
     end
 

--- a/src/hagerzhang.jl
+++ b/src/hagerzhang.jl
@@ -104,14 +104,14 @@ HagerZhang{T}(args...; kwargs...) where T = HagerZhang{T, Base.RefValue{Bool}}(a
 function (ls::HagerZhang)(df::AbstractObjective, x::AbstractArray{T},
                           s::AbstractArray{T}, α::Real,
                           x_new::AbstractArray{T}, phi_0::Real, dphi_0::Real) where T
-    ϕ, ϕdϕ = make_ϕ_ϕdϕ(df, x_new, x, s)
-    ls(ϕ, ϕdϕ, α::Real, phi_0, dphi_0)
+    ϕdϕ = make_ϕdϕ(df, x_new, x, s)
+    ls(ϕdϕ, α, phi_0, dphi_0)
 end
 
-(ls::HagerZhang)(ϕ, dϕ, ϕdϕ, c, phi_0, dphi_0) = ls(ϕ, ϕdϕ, c, phi_0, dphi_0)
+(ls::HagerZhang)(ϕ, dϕ, ϕdϕ, c, phi_0, dphi_0) = ls(ϕdϕ, c, phi_0, dphi_0)
 
-# TODO: Should we deprecate the interface that only uses the ϕ and ϕd\phi arguments?
-function (ls::HagerZhang)(ϕ, ϕdϕ,
+# we really just need ϕdϕ
+function (ls::HagerZhang)(ϕdϕ,
                           c::T,
                           phi_0::Real,
                           dphi_0::Real) where T # Should c and phi_0 be same type?

--- a/src/hagerzhangls.jl
+++ b/src/hagerzhangls.jl
@@ -430,11 +430,12 @@ function (ls::HagerZhangLS)(df::AbstractObjective, x::AbstractArray{T},
                             x_new::AbstractArray{T} = similar(x),
                             ϕ_0 = nothing, dϕ_0 = nothing) where {T}
     ϕ, dϕ, ϕdϕ = make_ϕ_dϕ_ϕdϕ(df, x_new, x, s)
-    if isnothing(ϕ_0)
+    if isnothing(ϕ_0) && isnothing(dϕ_0)
+        ϕ_0, dϕ_0 = ϕdϕ(real(T)(0))
+    elseif isnothing(ϕ_0)
         ϕ_0 = ϕ(real(T)(0))
-    end
-    if isnothing(dϕ_0)
+    elseif isnothing(dϕ_0)
         dϕ_0 = dϕ(real(T)(0))
     end
-    ls(ϕ, dϕ, ϕdϕ, α, ϕ_0, dϕ_0)
+    ls(ϕdϕ, α, ϕ_0, dϕ_0)
 end

--- a/src/strongwolfe.jl
+++ b/src/strongwolfe.jl
@@ -82,7 +82,7 @@ function (ls::StrongWolfe)(ϕ, dϕ, ϕdϕ,
             (ϕ_a_i >= ϕ_a_iminus1 && i > 1)
             a_star = zoom(a_iminus1, a_i,
                           dϕ_0, ϕ_0,
-                          ϕ, dϕ, ϕdϕ, cache)
+                          ϕdϕ, cache, c_1, c_2)
             return a_star, ϕ(a_star)
         end
 
@@ -99,7 +99,7 @@ function (ls::StrongWolfe)(ϕ, dϕ, ϕdϕ,
         # Check condition 3
         if dϕ_a_i >= zero(T) # FIXME untested!
             a_star = zoom(a_i, a_iminus1,
-                          dϕ_0, ϕ_0, ϕ, dϕ, ϕdϕ, cache)
+                          dϕ_0, ϕ_0, ϕdϕ, cache, c_1, c_2)
             return a_star, ϕ(a_star)
         end
 
@@ -121,15 +121,21 @@ function zoom(a_lo::T,
               a_hi::T,
               dϕ_0::Real,
               ϕ_0::Real,
-              ϕ,
-              dϕ,
               ϕdϕ,
               cache,
-              c_1::Real = convert(T, 1)/10^4,
-              c_2::Real = convert(T, 9)/10) where T
+              c_1::Real,
+              c_2::Real) where T
 
     # Step-size
     a_j = convert(T, NaN)
+
+    # The endpoints are only ever reassigned to already-evaluated points, so their
+    # values and slopes are carried through the loop rather than recomputed.
+    ϕ_a_lo, ϕprime_a_lo = ϕdϕ(a_lo)
+    pushcache!(cache, a_lo, ϕ_a_lo, ϕprime_a_lo)
+
+    ϕ_a_hi, ϕprime_a_hi = ϕdϕ(a_hi)
+    pushcache!(cache, a_hi, ϕ_a_hi, ϕprime_a_hi)
 
     # Count iterations
     iteration = 0
@@ -138,12 +144,6 @@ function zoom(a_lo::T,
     # Shrink bracket
     while iteration < max_iterations
         iteration += 1
-
-        ϕ_a_lo, ϕprime_a_lo = ϕdϕ(a_lo)
-        pushcache!(cache, a_lo, ϕ_a_lo, ϕprime_a_lo)
-
-        ϕ_a_hi, ϕprime_a_hi = ϕdϕ(a_hi)
-        pushcache!(cache, a_hi, ϕ_a_hi, ϕprime_a_hi)
 
         # Interpolate a_j
         if a_lo < a_hi
@@ -157,30 +157,25 @@ function zoom(a_lo::T,
                               ϕprime_a_hi, ϕprime_a_lo)
         end
 
-        # Evaluate ϕ(a_j)
-        ϕ_a_j = ϕ(a_j)
-        pushcache!(cache, a_j, ϕ_a_j)
+        # a_j becomes an endpoint in every branch below, so its slope is needed either way
+        ϕ_a_j, ϕprime_a_j = ϕdϕ(a_j)
+        pushcache!(cache, a_j, ϕ_a_j, ϕprime_a_j)
 
         # Check Armijo
         if (ϕ_a_j > ϕ_0 + c_1 * a_j * dϕ_0) ||
             (ϕ_a_j > ϕ_a_lo)
-            a_hi = a_j
+            a_hi, ϕ_a_hi, ϕprime_a_hi = a_j, ϕ_a_j, ϕprime_a_j
         else
-            # Evaluate ϕprime(a_j)
-            ϕprime_a_j = dϕ(a_j)
-            if !isnothing(cache)
-                push!(cache.slopes, ϕprime_a_j)
-            end
-
             if abs(ϕprime_a_j) <= -c_2 * dϕ_0
                 return a_j
             end
 
+            # Reads the bracket width before a_lo moves below
             if ϕprime_a_j * (a_hi - a_lo) >= zero(T)
-                a_hi = a_lo
+                a_hi, ϕ_a_hi, ϕprime_a_hi = a_lo, ϕ_a_lo, ϕprime_a_lo
             end
 
-            a_lo = a_j
+            a_lo, ϕ_a_lo, ϕprime_a_lo = a_j, ϕ_a_j, ϕprime_a_j
         end
     end
 

--- a/test/captured.jl
+++ b/test/captured.jl
@@ -40,7 +40,7 @@ end
     )
     fdf = OnceDifferentiable(tc)
     hz = HagerZhang()
-    α, val = hz(fdf.f, fdf.fdf, 1.0, fdf.fdf(0.0)...)
+    α, val = hz(fdf.fdf, 1.0, fdf.fdf(0.0)...)
     @test val <= minimum(tc)
 end
 
@@ -69,7 +69,7 @@ end
         cache = LineSearchCache{Float64}()
         hz = HagerZhang(; cache)
         ϕdϕ_counted, count = counting_ϕdϕ(ϕdϕ_quad)
-        α, val = hz(ϕ_quad, ϕdϕ_counted, 10.0, ϕ_quad(0.0), dϕ_quad(0.0))
+        α, val = hz(ϕdϕ_counted, 10.0, ϕ_quad(0.0), dϕ_quad(0.0))
         # The result must satisfy Wolfe conditions
         ϕ0 = ϕ_quad(0.0)
         dϕ0 = dϕ_quad(0.0)
@@ -151,7 +151,7 @@ end
         ϕ0 = ϕ_steep(0.0)
         dϕ0 = dϕ_steep(0.0)
         ϕdϕ_counted, count = counting_ϕdϕ(ϕdϕ_steep)
-        α, val = hz(ϕ_steep, ϕdϕ_counted, 0.1, ϕ0, dϕ0)
+        α, val = hz(ϕdϕ_counted, 0.1, ϕ0, dϕ0)
 
         ϵ = hz.epsilon
         phi_lim = ϕ0 + ϵ * abs(ϕ0)
@@ -171,7 +171,7 @@ end
         # Run and verify: should terminate with α=0.5
         cache = LineSearchCache{Float64}()
         hz = HagerZhang(; cache)
-        α, val = hz(ϕ_steep, ϕdϕ_steep, 0.1, ϕ0, dϕ0)
+        α, val = hz(ϕdϕ_steep, 0.1, ϕ0, dϕ0)
         @test α == 0.5
         @test val == ϕ_steep(0.5)
         # Only 2 cached evals: initial c=0.1, then expansion to c=0.5
@@ -189,7 +189,7 @@ end
         fdf = OnceDifferentiable(tc)
         cache = LineSearchCache{Float64}()
         hz = HagerZhang(; cache, check_flatness=true)
-        α, val = hz(fdf.f, fdf.fdf, 1.0, fdf.fdf(0.0)...)
+        α, val = hz(fdf.fdf, 1.0, fdf.fdf(0.0)...)
         @test minimum(cache.values) == val
     end
 end

--- a/test/evalcounts.jl
+++ b/test/evalcounts.jl
@@ -1,0 +1,80 @@
+@testset "Evaluation counts" begin
+    # `only_fg!` passes `nothing` for the slot it does not want, so logging the requested
+    # slots shows whether a fused or a split evaluation was used. NLSolversBase's own
+    # f_calls/g_calls cannot tell them apart.
+    f(x) = sum(abs2, x) + 0.1 * sum(z -> z^4, x)
+    ∇f(x) = 2 .* x .+ 0.4 .* x .^ 3
+
+    function counted()
+        log = Symbol[]
+        function fdf(F, G, x)
+            push!(log, F === nothing ? :grad : (G === nothing ? :val : :fused))
+            G === nothing || (G .= ∇f(x))
+            F === nothing || return f(x)
+            return nothing
+        end
+        return fdf, log
+    end
+    objective(fdf, x) =
+        NLSolversBase.OnceDifferentiable(NLSolversBase.only_fg!(fdf), copy(x), 0.0)
+
+    x = [1.0, 2.0, 3.0]
+    s = -[2.0, 4.0, 6.0]
+    ϕ_0 = f(x)
+    dϕ_0 = sum(∇f(x) .* s)
+
+    lss = (BackTracking(), BackTracking(; order = 2), LineSearches.HagerZhangLS())
+
+    @testset "α=0: $(nameof(typeof(ls)))" for ls in lss
+        fdf, log = counted()
+        α, val = ls(objective(fdf, x), x, s, 1.0, similar(x))
+        @test first(log) == :fused
+        @test count(==(:grad), log) == 0
+        @test α ≈ 0.5
+        @test val ≈ f(x .+ α .* s)
+
+        # A supplied endpoint keeps the narrower call
+        fdf, log = counted()
+        ls(objective(fdf, x), x, s, 1.0, similar(x), ϕ_0, nothing)
+        @test first(log) == :grad
+
+        fdf, log = counted()
+        ls(objective(fdf, x), x, s, 1.0, similar(x), nothing, dϕ_0)
+        @test first(log) == :val
+    end
+
+    # Steep descent with a flat tail, so a tight c_2 makes zoom iterate
+    ψ(α) = -α / (1 + 10α^2) + 0.02α^2
+    dψ(α) = -(1 - 10α^2) / (1 + 10α^2)^2 + 0.04α
+
+    # zoom reassigns its endpoints only to already-evaluated points, so it costs 2
+    # evaluations to seed the bracket plus 1 per iteration (was ~4 per iteration).
+    @testset "zoom, c_2=$c_2" for (c_2, entries, expected) in
+            ((0.5, 3, 0.412201859), (0.1, 4, 0.3461435202), (0.01, 7, 0.312411912))
+        n = Ref(0)
+        ϕdϕ = α -> (n[] += 1; (ψ(α), dψ(α)))
+        a = LineSearches.zoom(0.0, 1.0, dψ(0.0), ψ(0.0), ϕdϕ, nothing, 1e-4, c_2)
+        @test a ≈ expected
+        @test n[] == entries
+    end
+
+    # zoom used to default c_1/c_2 in its signature and neither call site passed them,
+    # so a tight c_2 was ignored and the returned step violated the curvature condition.
+    @testset "c_2 is honoured, c_2=$c_2" for c_2 in (0.1, 0.05, 0.01)
+        α, val = StrongWolfe(; c_2)(ψ, dψ, α -> (ψ(α), dψ(α)), 1.0, ψ(0.0), dψ(0.0))
+        @test abs(dψ(α)) <= c_2 * abs(dψ(0.0))
+        @test val ≈ ψ(α)
+    end
+
+    # HagerZhang stores every evaluated point, so it should never ask for the same α twice
+    problems = ((ψ, dψ),
+                (α -> (α^2 - 11)^2 + (α - 7)^2, α -> 4α * (α^2 - 11) + 2(α - 7)),
+                (α -> 1 - 1 / (1 + (α - 2)^2), α -> 2(α - 2) / (1 + (α - 2)^2)^2))
+    @testset "HagerZhang evaluates each α once" for (g, dg) in problems,
+                                                    α0 in (0.1, 1.0, 5.0)
+        seen = Float64[]
+        α, val = HagerZhang()(α -> (push!(seen, α); (g(α), dg(α))), α0, g(0.0), dg(0.0))
+        @test allunique(seen)
+        @test val ≈ g(α)
+    end
+end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -124,7 +124,7 @@ res = (StrongWolfe())(ϕ, dϕ, ϕdϕ, α0, ϕ0, dϕ0)
             hz = HagerZhang(; cache, check_flatness)
             f = tc_to_f(tc)
             fdf = tc_to_fdf(tc)
-            hz(f, fdf, 1.0, fdf(0.0)...), cache
+            hz(fdf, 1.0, fdf(0.0)...), cache
         end
 
         res, res_cache = test_tc(tc1, true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ my_tests = [
     "alphacalc.jl",
     "arbitrary_precision.jl",
     "captured.jl",
+    "evalcounts.jl",
     "issues.jl",
     "qa.jl",
 ]


### PR DESCRIPTION
## Summary

An audit of the separate value / directional-derivative helpers (`make_ϕ_dϕ` and friends) turned up one correctness bug and a few avoidable objective evaluations.

`NLSolversBase` v8 caches value and JVP independently, so `ϕ(α)` followed by `dϕ(α)` does **not** recompute the value — the split is about laziness, not caching. What it does lose is the fused path: `ϕdϕ` routes to `obj.fdf`/`obj.fjvp` in one pass, while the split routes to `obj.f` then `obj.df`. That matters for objectives built from AD (where `fg!` wraps `DI.value_and_gradient!`) or from `only_fg!`.

## `StrongWolfe` silently ignored `c_1` and `c_2`

`zoom` declared them as defaulted parameters and **neither call site passed them**, so a tight `c_2` was discarded and the returned step could violate the strong Wolfe curvature condition the algorithm exists to guarantee:

| | `c_2=0.1` | `c_2=0.05` | `c_2=0.01` |
|---|---|---|---|
| before | α=0.412201859, **violated** | α=0.412201859, **violated** | α=0.412201859, **violated** |
| after | α=0.3461435202, ok | α=0.3254206354, ok | α=0.312411912, ok |

Identical α for every tightening, all failing `\|ϕ'(α)\| ≤ c_2\|ϕ'(0)\|`. This changes results only for non-default `c_1`/`c_2`.

## `zoom` re-evaluated its bracket endpoints every iteration

`a_lo` and `a_hi` are only ever reassigned to already-evaluated points, so their values and slopes are now carried as loop state. `a_j` becomes an endpoint in every branch, so evaluating its slope eagerly costs nothing and is what makes the reuse possible.

Measured by calling `zoom` directly with identical arguments — **bit-identical `a_star`** in every case:

| `c_2` | 0.5 | 0.1 | 0.05 | 0.01 |
|---|---|---|---|---|
| before | 4 | 8 | 12 | 20 |
| after | 3 | 4 | 5 | **7** |

~4 evaluations per iteration → 1.

## `α=0` is now one fused evaluation

`BackTracking` and `HagerZhangLS` evaluated value and derivative at α=0 back to back with no branch between, so the laziness bought nothing. They now use `ϕdϕ` when both endpoints are missing, keeping the narrower call when the caller supplied one.

## `HagerZhang` cleanup

`ϕ` appeared exactly twice in `hagerzhang.jl`: constructed via `make_ϕ_ϕdϕ`, and as an ignored parameter of the 5-arg method. Every helper it uses (`secant2!`, `update!`, `bisect!`) takes only `ϕdϕ`. The body moves to the 4-arg `(ls)(ϕdϕ, c, phi_0, dphi_0)` shape `MoreThuente` and `HagerZhangLS` already use, and `make_ϕ_ϕdϕ` is deleted. Saves ~48 bytes/call and answers the TODO about deprecating that interface.

Benchmarked across 18 scenarios (6 functions × 3 starting steps): **identical α\*, identical evaluation counts (48 total), zero duplicate α**. HagerZhang already kept `alphas`/`values`/`slopes` arrays and served revisited points from them, so there was nothing to fix — only the dead closure to remove.

## Compatibility

The 6-arg uniform interface (`README.md`) is untouched. Optim only calls the 7-arg `df` method, and its `alphaguess!` path hands `ls` to `InitialHagerZhang`, which reads only `ls.mayterminate[]`. The removed 5-arg `HagerZhang` form had no callers outside this repo's own tests, hence the patch-level bump to `7.7.2`.

## Tests

New `test/evalcounts.jl` (48 assertions). `NLSolversBase`'s own `f_calls`/`g_calls` cannot distinguish fused from split — `value_jacobian!!` bumps both — so it logs which slots `only_fg!` was asked for. Covers the fused-vs-split path per line search, `zoom`'s per-iteration cost, the `c_2` contract, and that `HagerZhang` never evaluates the same α twice (7 of its 9 cases make multiple evaluations, so the check isn't vacuous).

Full suite passes, including `qa.jl` (Aqua / ExplicitImports / JET).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
