### PR TITLE
Audit the remaining line searches: safeguards, duplicate evaluations, dead code

### DIFF
--- a/src/LineSearches.jl
+++ b/src/LineSearches.jl
@@ -68,6 +68,25 @@ end
 pushcache!(::Nothing, α, val, slope) = nothing
 pushcache!(::Nothing, α, val) = nothing
 
+"""
+    cubic_d1_d2(a1, ϕ1, dϕ1, a2, ϕ2, dϕ2)
+
+The terms `d1` and `d2` of the Hermite cubic through both points, Nocedal and Wright,
+2nd ed, (3.59), whose minimiser is
+
+    a2 - (a2 - a1) * (dϕ2 + d2 - d1) / (dϕ2 - dϕ1 + 2 * d2)
+
+Scaling by `s` keeps `d1^2` from overflowing and the product of the slopes from
+underflowing. The radicand can go negative when the two slopes share a sign, and is
+clamped at zero; `NaNMath` also covers `s == 0`, where the ratios are `NaN`.
+"""
+function cubic_d1_d2(a1::Real, ϕ1::Real, dϕ1::Real, a2::Real, ϕ2::Real, dϕ2::Real)
+    d1 = 3 * (ϕ1 - ϕ2) / (a2 - a1) + dϕ1 + dϕ2
+    s = max(abs(d1), abs(dϕ1), abs(dϕ2))
+    d2 = s * sqrt(NaNMath.max(zero(s), (d1 / s)^2 - (dϕ1 / s) * (dϕ2 / s)))
+    return d1, d2
+end
+
 # Line Search Methods
 include("backtracking.jl")
 include("strongwolfe.jl")

--- a/src/LineSearches.jl
+++ b/src/LineSearches.jl
@@ -33,14 +33,17 @@ function make_ϕdϕ(df, x_new, x, s)
     end
     ϕdϕ
 end
-function make_ϕ_dϕ(df, x_new, x, s)
+function make_dϕ(df, x_new, x, s)
     function dϕ(α)
         # Move a distance of alpha in the direction of s
         x_new .= muladd.(α, s, x)
         # Calculate ϕ'(a_i)
         return real(NLSolversBase.jvp!(df, x_new, s))
     end
-    make_ϕ(df, x_new, x, s), dϕ
+    dϕ
+end
+function make_ϕ_dϕ(df, x_new, x, s)
+    make_ϕ(df, x_new, x, s), make_dϕ(df, x_new, x, s)
 end
 function make_ϕ_dϕ_ϕdϕ(df, x_new, x, s)
     make_ϕ_dϕ(df, x_new, x, s)..., make_ϕdϕ(df, x_new, x, s)

--- a/src/backtracking.jl
+++ b/src/backtracking.jl
@@ -85,18 +85,18 @@ function (ls::BackTracking)(ϕ, αinitial::Tα, ϕ_0, dϕ_0) where Tα
     # Count the total number of iterations
     iteration = 0
 
-    ϕx_0, ϕx_1 = ϕ_0, ϕ_0
+    # The cubic branch pairs (α_1, ϕx_0) with (α_2, ϕx_1); α_1 is reassigned in the
+    # loop below before that branch can first run
+    ϕx_0 = ϕ_0
+    α_1 = α_2 = αinitial
 
-    α_1, α_2 = αinitial, αinitial
-
-    ϕx_1 = ϕ(α_1)
+    ϕx_1 = ϕ(α_2)
 
     # Hard-coded backtrack until we find a finite function value
     iterfinite = 0
     while !isfinite(ϕx_1) && iterfinite < iterfinitemax
         iterfinite += 1
-        α_1 = α_2
-        α_2 = α_1/2
+        α_2 /= 2
 
         ϕx_1 = ϕ(α_2)
     end
@@ -131,7 +131,7 @@ function (ls::BackTracking)(ϕ, αinitial::Tα, ϕ_0, dϕ_0) where Tα
             a = (α_1^2*(ϕx_1 - ϕ_0 - dϕ_0*α_2) - α_2^2*(ϕx_0 - ϕ_0 - dϕ_0*α_1))*div
             b = (-α_1^3*(ϕx_1 - ϕ_0 - dϕ_0*α_2) + α_2^3*(ϕx_0 - ϕ_0 - dϕ_0*α_1))*div
 
-            if isapprox(a, zero(a), atol=eps(real(Tα)))
+            if iszero(a)
                 α_tmp = -dϕ_0 / (2*b)
             else
                 # discriminant

--- a/src/backtracking.jl
+++ b/src/backtracking.jl
@@ -18,7 +18,33 @@ Sec. 3.5.
     order::TI = 3
     maxstep::TF = Inf
     cache::Union{Nothing,LineSearchCache{TF}} = nothing
+
+    function BackTracking{TF,TI}(c_1, ρ_hi, ρ_lo, iterations, order, maxstep, cache) where {TF,TI}
+        if !(0 < c_1 < 1)
+            throw(ArgumentError(
+                LazyString("The Armijo constant must satisfy 0 < c_1 < 1. Got c_1 = ", c_1),
+            ))
+        end
+        if !(0 < ρ_lo <= ρ_hi < 1)
+            throw(ArgumentError(
+                LazyString("The backtracking factors must satisfy 0 < ρ_lo <= ρ_hi < 1. Got ρ_lo = ", ρ_lo, " and ρ_hi = ", ρ_hi),
+            ))
+        end
+        if !(order in (2, 3))
+            throw(ArgumentError(LazyString("The interpolation order must be 2 or 3. Got order = ", order)))
+        end
+        if !(iterations > 0)
+            throw(ArgumentError(LazyString("The iteration limit must be positive. Got iterations = ", iterations)))
+        end
+        if !(maxstep > 0)
+            throw(ArgumentError(LazyString("The maximum step length must be positive. Got maxstep = ", maxstep)))
+        end
+        return new{TF,TI}(c_1, ρ_hi, ρ_lo, iterations, order, maxstep, cache)
+    end
 end
+BackTracking(c_1::TF, ρ_hi::TF, ρ_lo::TF, iterations::TI, order::TI, maxstep::TF,
+             cache::Union{Nothing,LineSearchCache{TF}}) where {TF,TI} =
+    BackTracking{TF,TI}(c_1, ρ_hi, ρ_lo, iterations, order, maxstep, cache)
 BackTracking{TF}(args...; kwargs...) where TF = BackTracking{TF,Int}(args...; kwargs...)
 
 function (ls::BackTracking)(df::AbstractObjective, x::AbstractArray{T}, s::AbstractArray{T},
@@ -45,16 +71,15 @@ function (ls::BackTracking)(ϕ, αinitial::Tα, ϕ_0, dϕ_0) where Tα
     emptycache!(cache)
     pushcache!(cache, 0, ϕ_0, dϕ_0)  # backtracking doesn't use the slope except here
 
-    iterfinitemax = -log2(eps(real(Tα)))
+    if !(isfinite(ϕ_0) && isfinite(dϕ_0))
+        throw(LineSearchException("Value and slope at step length = 0 must be finite.", zero(Tα)))
+    end
+    # dϕ_0 == 0 is accepted: Armijo then reduces to a plain decrease test
+    if dϕ_0 > 0
+        throw(LineSearchException("Search direction is not a direction of descent.", zero(Tα)))
+    end
 
-    @assert order in (2,3)
-    # Check the input is valid, and modify otherwise
-    #backtrack_condition = 1.0 - 1.0/(2*ρ) # want guaranteed backtrack factor
-    #if c_1 >= backtrack_condition
-    #    warn("""The Armijo constant c_1 is too large; replacing it with
-    #                   $(backtrack_condition)""")
-    #   c_1 = backtrack_condition
-    #end
+    iterfinitemax = -log2(eps(real(Tα)))
 
     # Count the total number of iterations
     iteration = 0
@@ -74,7 +99,7 @@ function (ls::BackTracking)(ϕ, αinitial::Tα, ϕ_0, dϕ_0) where Tα
 
         ϕx_1 = ϕ(α_2)
     end
-    pushcache!(cache, αinitial, ϕx_1)
+    pushcache!(cache, α_2, ϕx_1)
     if !isfinite(ϕx_1)
         throw(LineSearchException("Backtracking: failed to achieve finite new evaluation point.", α_2))
     end

--- a/src/backtracking.jl
+++ b/src/backtracking.jl
@@ -49,14 +49,15 @@ BackTracking{TF}(args...; kwargs...) where TF = BackTracking{TF,Int}(args...; kw
 
 function (ls::BackTracking)(df::AbstractObjective, x::AbstractArray{T}, s::AbstractArray{T},
                             α_0::Tα = real(T)(1), x_new::AbstractArray{T} = similar(x), ϕ_0 = nothing, dϕ_0 = nothing, alphamax = typemax(real(T))) where {T, Tα}
-    ϕ, dϕ, ϕdϕ = make_ϕ_dϕ_ϕdϕ(df, x_new, x, s)
+    # The search itself only ever needs ϕ; the others fill in a missing endpoint
+    ϕ = make_ϕ(df, x_new, x, s)
 
     if isnothing(ϕ_0) && isnothing(dϕ_0)
-        ϕ_0, dϕ_0 = ϕdϕ(zero(Tα))
+        ϕ_0, dϕ_0 = make_ϕdϕ(df, x_new, x, s)(zero(Tα))
     elseif isnothing(ϕ_0)
         ϕ_0 = ϕ(zero(Tα))
     elseif isnothing(dϕ_0)
-        dϕ_0 = dϕ(zero(Tα))
+        dϕ_0 = make_dϕ(df, x_new, x, s)(zero(Tα))
     end
 
     α_0 = min(α_0, min(alphamax, ls.maxstep / norm(s, Inf)))

--- a/src/hagerzhang.jl
+++ b/src/hagerzhang.jl
@@ -115,9 +115,15 @@ function (ls::HagerZhang)(ϕdϕ,
                           c::T,
                           phi_0::Real,
                           dphi_0::Real) where T # Should c and phi_0 be same type?
-    (; delta, sigma, alphamax, rho, epsilon, gamma,
+    (; delta, sigma, rho, epsilon, gamma,
             linesearchmax, psi3, display, mayterminate, cache) = ls
+    # Shrinks below ls.alphamax once a non-finite evaluation marks a feasibility bound
+    alphamax = ls.alphamax
     emptycache!(cache)
+
+    # InitialHagerZhang sets this to flag a quadratic-interpolation guess. The early
+    # Wolfe check below now runs either way, so consuming it is all that is left.
+    mayterminate[] = false
 
     pushcache!(cache, zero(T), phi_0, dphi_0)
     if !(isfinite(phi_0) && isfinite(dphi_0))
@@ -158,13 +164,11 @@ function (ls::HagerZhang)(ϕdϕ,
     phi_c, dphi_c = ϕdϕ(c)
     iterfinite = 1
     while !(isfinite(phi_c) && isfinite(dphi_c)) && iterfinite < iterfinitemax
-        mayterminate[] = false
         iterfinite += 1
         c *= psi3
         phi_c, dphi_c = ϕdϕ(c)
     end
     if !(isfinite(phi_c) && isfinite(dphi_c))
-        mayterminate[] = false # reset in case another initial guess is used next
         throw(LineSearchException("Failed to achieve finite new evaluation point.", c))
     end
     push!(alphas, c)
@@ -176,9 +180,6 @@ function (ls::HagerZhang)(ϕdϕ,
     if satisfies_wolfe(c, phi_c, dphi_c, phi_0, dphi_0, phi_lim, delta, sigma)
         if display & LINESEARCH > 0
             println("Wolfe condition satisfied on point alpha = ", c)
-        end
-        if mayterminate[] # this previously was in front of satisfies_wolfe but it should be fine to always check initial convergence
-            mayterminate[] = false # reset in case another initial guess is used next
         end
         return c, phi_c # phi_c
     end
@@ -219,7 +220,6 @@ function (ls::HagerZhang)(ϕdϕ,
             # ia, ib = bisect(phi, lsr, ia, ib, phi_lim) # TODO: Pass options
             ia, ib, iswolfe = bisect!(ϕdϕ, alphas, values, slopes, ia, ib, phi_lim, phi_0, dphi_0, delta, sigma, display)
             if iswolfe
-                mayterminate[] = false
                 return alphas[ib], values[ib]
             end
             isbracketed = true
@@ -239,10 +239,8 @@ function (ls::HagerZhang)(ϕdϕ,
                     # The recovery loop below shrunk `alphamax` from the
                     # user-supplied cap, so we're pinned at a non-finite
                     # feasibility boundary and cannot make further progress.
-                    mayterminate[] = false
                     throw(LineSearchException("Failed to bracket: pinned at non-finite feasibility boundary.", cold))
                 end
-                mayterminate[] = false # reset in case another initial guess is used next
                 return cold, phi_cold
             end
             c *= rho
@@ -284,7 +282,6 @@ function (ls::HagerZhang)(ϕdϕ,
                 if display & LINESEARCH > 0
                     println("Wolfe condition satisfied during bracketing at alpha = ", c)
                 end
-                mayterminate[] = false
                 return c, phi_c
             end
         end
@@ -303,12 +300,10 @@ function (ls::HagerZhang)(ϕdϕ,
                     ", phi(b) = ", values[ib])
         end
         if b - a <= eps(b)
-            mayterminate[] = false # reset in case another initial guess is used next
             return a, values[ia] # lsr.value[ia]
         end
-        iswolfe, iA, iB = secant2!(ϕdϕ, alphas, values, slopes, ia, ib, phi_lim, delta, sigma, display)
+        iswolfe, iA, iB = secant2!(ϕdϕ, alphas, values, slopes, ia, ib, phi_lim, phi_0, dphi_0, delta, sigma, display)
         if iswolfe
-            mayterminate[] = false # reset in case another initial guess is used next
             return alphas[iA], values[iA] # lsr.value[iA]
         end
         A = alphas[iA]
@@ -323,7 +318,6 @@ function (ls::HagerZhang)(ϕdϕ,
                 if display & LINESEARCH > 0
                     println("Linesearch: secant suggests it's flat")
                 end
-                mayterminate[] = false # reset in case another initial guess is used next
 
                 return A, values[iA]
             end
@@ -345,13 +339,11 @@ function (ls::HagerZhang)(ϕdϕ,
                 if display & LINESEARCH > 0
                     println("Wolfe condition satisfied during bisection at alpha = ", c)
                 end
-                mayterminate[] = false
                 return c, phi_c
             end
 
             ia, ib, iswolfe = update!(ϕdϕ, alphas, values, slopes, iA, iB, length(alphas), phi_lim, phi_0, dphi_0, delta, sigma, display)
             if iswolfe
-                mayterminate[] = false
                 return alphas[ib], values[ib]
             end
         end
@@ -384,7 +376,7 @@ end
 function secant(a::Real, b::Real, dphi_a::Real, dphi_b::Real)
     return (a * dphi_b - b * dphi_a) / (dphi_b - dphi_a)
 end
-function secant(alphas, values, slopes, ia::Integer, ib::Integer)
+function secant(alphas::AbstractArray, slopes::AbstractArray, ia::Integer, ib::Integer)
     return secant(alphas[ia], alphas[ib], slopes[ia], slopes[ib])
 end
 # phi
@@ -395,11 +387,11 @@ function secant2!(ϕdϕ,
                   ia::Integer,
                   ib::Integer,
                   phi_lim::Real,
+                  phi_0::Real,
+                  dphi_0::Real,
                   delta::Real = DEFAULTDELTA,
                   sigma::Real = DEFAULTSIGMA,
                   display::Integer = 0)
-    phi_0 = values[1]
-    dphi_0 = slopes[1]
     a = alphas[ia]
     b = alphas[ib]
     dphi_a = slopes[ia]
@@ -444,13 +436,12 @@ function secant2!(ϕdϕ,
     end
     a = alphas[iA]
     b = alphas[iB]
-    doupdate = false
     if iB == ic
         # we updated b, make sure we also update a
-        c = secant(alphas, values, slopes, ib, iB)
+        c = secant(alphas, slopes, ib, iB)
     elseif iA == ic
         # we updated a, do it for b too
-        c = secant(alphas, values, slopes, ia, iA)
+        c = secant(alphas, slopes, ia, iA)
     end
     if (iA == ic || iB == ic) && a <= c <= b
         if display & SECANT2 > 0
@@ -556,7 +547,6 @@ function bisect!(ϕdϕ,
                  delta::Real,
                  sigma::Real,
                  display::Integer = 0) where T
-    gphi = convert(T, NaN)
     a = alphas[ia]
     b = alphas[ib]
     # Debugging (HZ, conditions shown following U3)

--- a/src/hagerzhang.jl
+++ b/src/hagerzhang.jl
@@ -358,7 +358,8 @@ function (ls::HagerZhang)(ϕdϕ,
         iter += 1
     end
 
-    best_alpha = alphas[argmin(values)]
+    # bisect! stores every point it evaluates, so `values` may contain NaN
+    best_alpha = alphas[last(NaNMath.findmin(values))]
     throw(LineSearchException("Linesearch failed to converge, reached maximum iterations $(linesearchmax).",
                               best_alpha))
 end

--- a/src/initialguess.jl
+++ b/src/initialguess.jl
@@ -79,7 +79,7 @@ end
 function (is::InitialQuadratic{T})(ls, state, phi_0, dphi_0, df) where T
     # phi_0 is (or should be) equal to NLSolversBase.value(df, state.x) and `state.f_x`
     @assert !hasproperty(state, :f_x) || phi_0 == state.f_x
-    if !isfinite(state.f_x_previous) || isapprox(dphi_0, zero(T), atol=eps(T)) # Need to add a tolerance
+    if !isfinite(state.f_x_previous) || iszero(dphi_0)
         # If we're at the first iteration
         αguess = is.α0
     else
@@ -149,8 +149,7 @@ end
 function (is::InitialConstantChange{T})(ls, state, phi_0, dphi_0, df) where T
     # phi_0 is (or should be) equal to NLSolversBase.value(df, state.x) and `state.f_x`
     @assert !hasproperty(state, :f_x) || phi_0 == state.f_x
-    if !isfinite(is.dϕ_0_previous[]) || !isfinite(state.alpha) ||
-        isapprox(dphi_0, zero(T), atol=eps(T))
+    if !isfinite(is.dϕ_0_previous[]) || !isfinite(state.alpha) || iszero(dphi_0)
         # If we're at the first iteration
         αguess = is.α0
     else

--- a/src/morethuente.jl
+++ b/src/morethuente.jl
@@ -244,6 +244,11 @@ function (ls::MoreThuente)(ϕdϕ,
     end
     pushcache!(cache, alpha, f, dg)
 
+    # `f` and `dg` are the evaluation at `alpha_checked`, which the first pass below
+    # reuses unless the bound clamping moves the step away from it
+    alpha_checked = alpha
+    firstpass = true
+
     while true
         #
         # Set the minimum and maximum steps to correspond
@@ -287,9 +292,12 @@ function (ls::MoreThuente)(ϕdϕ,
         # Evaluate the function and gradient at alpha
         # and compute the directional derivative.
         #
-        f, dg = ϕdϕ(alpha)
-        pushcache!(cache, alpha, f, dg)
-        nfev += 1 # This includes calls to f() and g!()
+        if !(firstpass && alpha == alpha_checked)
+            f, dg = ϕdϕ(alpha)
+            pushcache!(cache, alpha, f, dg)
+            nfev += 1 # This includes calls to f() and g!()
+        end
+        firstpass = false
 
         # Recover from a non-finite evaluation by bisecting toward stx
         # (the best finite step seen so far) and shrink the local alphamax

--- a/src/morethuente.jl
+++ b/src/morethuente.jl
@@ -507,10 +507,7 @@ function cstep(stx::Real, fx::Real, dgx::Real,
    if f > fx
       info = 1
       bound = true
-      theta = 3 * (fx - f) / (alpha - stx) + dgx + dg
-      # Use s to prevent overflow/underflow of theta^2 and dgx * dg
-      s = max(abs(theta), abs(dgx), abs(dg))
-      gamma = s * sqrt((theta / s)^2 - (dgx / s) * (dg / s))
+      theta, gamma = cubic_d1_d2(stx, fx, dgx, alpha, f, dg)
       if alpha < stx
           gamma = -gamma
       end
@@ -536,10 +533,7 @@ function cstep(stx::Real, fx::Real, dgx::Real,
    elseif sgnd < zero(T)
       info = 2
       bound = false
-      theta = 3 * (fx - f) / (alpha - stx) + dgx + dg
-      # Use s to prevent overflow/underflow of theta^2 and dgx * dg
-      s = max(abs(theta), abs(dgx), abs(dg))
-      gamma = s * sqrt((theta / s)^2 - (dgx / s) * (dg / s))
+      theta, gamma = cubic_d1_d2(stx, fx, dgx, alpha, f, dg)
 
       if alpha > stx
          gamma = -gamma
@@ -570,15 +564,8 @@ function cstep(stx::Real, fx::Real, dgx::Real,
    elseif abs(dg) < abs(dgx)
       info = 3
       bound = true
-      theta = 3 * (fx - f) / (alpha - stx) + dgx + dg
-      # Use s to prevent overflow/underflow of theta^2 and dgx * dg
-      s = max(abs(theta), abs(dgx), abs(dg))
-      #
-      # The case gamma = 0 only arises if the cubic does not tend
-      # to infinity in the direction of the step
-      #
-      # # Use NaNMath in case s == zero(s)
-      gamma = s * sqrt(NaNMath.max(zero(s), (theta / s)^2 - (dgx / s) * (dg / s)))
+      # gamma = 0 only arises if the cubic does not tend to infinity along the step
+      theta, gamma = cubic_d1_d2(stx, fx, dgx, alpha, f, dg)
 
       if alpha > stx
           gamma = -gamma
@@ -619,10 +606,7 @@ function cstep(stx::Real, fx::Real, dgx::Real,
       info = 4
       bound = false
       if bracketed
-         theta = 3 * (f - fy) / (sty - alpha) + dgy + dg
-         # Use s to prevent overflow/underflow of theta^2 and dgy * dg
-         s = max(abs(theta), abs(dgy), abs(dg))
-         gamma = s * sqrt((theta / s)^2 - (dgy / s) * (dg / s))
+         theta, gamma = cubic_d1_d2(sty, fy, dgy, alpha, f, dg)
 
          if alpha > sty
              gamma = -gamma

--- a/src/morethuente.jl
+++ b/src/morethuente.jl
@@ -166,8 +166,10 @@ function (ls::MoreThuente)(ϕdϕ,
                            alpha::T,
                            ϕ_0,
                            dϕ_0) where T
-    (; f_tol, gtol, x_tol, alphamin, alphamax, maxfev, cache) = ls
+    (; f_tol, gtol, x_tol, alphamin, maxfev, cache) = ls
     emptycache!(cache)
+    # Shrinks below ls.alphamax once a non-finite evaluation marks a feasibility bound
+    alphamax = ls.alphamax
 
     iterfinitemax = -log2(eps(T))
 
@@ -319,10 +321,6 @@ function (ls::MoreThuente)(ϕdϕ,
             nfev += 1
         end
 
-        if isapprox(dg, 0, atol=eps(T)) # Should add atol value to MoreThuente
-            return alpha, f
-        end
-
         ftest1 = ϕ_0 + alpha * dgtest
 
         #
@@ -385,7 +383,7 @@ function (ls::MoreThuente)(ϕdϕ,
             stx, fxm, dgxm,
             sty, fym, dgym,
             alpha, fm, dgm,
-            bracketed, _ =
+            bracketed =
                 cstep(stx, fxm, dgxm, sty, fym, dgym,
                       alpha, fm, dgm, bracketed, stmin, stmax)
             #
@@ -403,7 +401,7 @@ function (ls::MoreThuente)(ϕdϕ,
             stx, fx, dgx,
             sty, fy, dgy,
             alpha, f, dg,
-            bracketed, _ =
+            bracketed =
                 cstep(stx, fx, dgx, sty, fy, dgy,
                       alpha, f, dg, bracketed, stmin, stmax)
         end
@@ -473,11 +471,6 @@ end # function
 # alphamin and alphamax are input variables which specify lower
 #   and upper bounds for the step
 #
-# info is an integer output variable set as follows:
-#   If info = 1,2,3,4,5, then the step has been computed
-#   according to one of the five cases below. Otherwise
-#   info = 0, and this indicates improper input parameters
-#
 # Argonne National Laboratory. MINPACK Project. June 1983
 # Jorge J. More', David J. Thuente
 
@@ -488,15 +481,15 @@ function cstep(stx::Real, fx::Real, dgx::Real,
 
    T = promote_type(typeof(stx), typeof(fx), typeof(dgx), typeof(sty), typeof(fy), typeof(dgy), typeof(alpha), typeof(f), typeof(dg), typeof(alphamin), typeof(alphamax))
    
-   info = 0
-
    #
    # Check the input parameters for error
    #
 
    if (bracketed && (alpha <= min(stx, sty) || alpha >= max(stx, sty))) ||
      dgx * (alpha - stx) >= zero(T) || alphamax < alphamin
-       throw(ArgumentError("Minimizer not bracketed"))
+       throw(LineSearchException(
+           LazyString("MoreThuente: cstep called with alpha = ", alpha, " outside the bracket [",
+                      min(stx, sty), ", ", max(stx, sty), "]."), alpha))
    end
 
    #
@@ -513,7 +506,6 @@ function cstep(stx::Real, fx::Real, dgx::Real,
    #
 
    if f > fx
-      info = 1
       bound = true
       theta, gamma = cubic_d1_d2(stx, fx, dgx, alpha, f, dg)
       if alpha < stx
@@ -539,7 +531,6 @@ function cstep(stx::Real, fx::Real, dgx::Real,
    #
 
    elseif sgnd < zero(T)
-      info = 2
       bound = false
       theta, gamma = cubic_d1_d2(stx, fx, dgx, alpha, f, dg)
 
@@ -570,7 +561,6 @@ function cstep(stx::Real, fx::Real, dgx::Real,
    #
 
    elseif abs(dg) < abs(dgx)
-      info = 3
       bound = true
       # gamma = 0 only arises if the cubic does not tend to infinity along the step
       theta, gamma = cubic_d1_d2(stx, fx, dgx, alpha, f, dg)
@@ -611,7 +601,6 @@ function cstep(stx::Real, fx::Real, dgx::Real,
    #
 
    else
-      info = 4
       bound = false
       if bracketed
          theta, gamma = cubic_d1_d2(sty, fy, dgy, alpha, f, dg)
@@ -666,5 +655,5 @@ function cstep(stx::Real, fx::Real, dgx::Real,
       end
    end
 
-   return stx, fx, dgx, sty, fy, dgy, alpha, f, dg, bracketed, info
+   return stx, fx, dgx, sty, fy, dgy, alpha, f, dg, bracketed
 end

--- a/src/static.jl
+++ b/src/static.jl
@@ -2,7 +2,7 @@
     Static()
 
 A static linesearch that accepts the initial step length unchanged (no parameters
-to configure).
+to configure), except that it halves the step until the objective is finite.
 
 `Static` is intended for methods with well-scaled updates; i.e. Newton, on
 well-behaved problems.
@@ -30,6 +30,9 @@ function (ls::Static)(ϕ, α::Tα) where Tα
         α    = αold/2
 
         ϕα = ϕ(α)
+    end
+    if !isfinite(ϕα)
+        throw(LineSearchException("Static: failed to achieve finite new evaluation point.", α))
     end
 
     return α, ϕα

--- a/src/static.jl
+++ b/src/static.jl
@@ -26,8 +26,7 @@ function (ls::Static)(ϕ, α::Tα) where Tα
     iterfinitemax = -log2(eps(real(Tα)))
     while !isfinite(ϕα) && iterfinite < iterfinitemax
         iterfinite += 1
-        αold = α
-        α    = αold/2
+        α /= 2
 
         ϕα = ϕ(α)
     end

--- a/src/strongwolfe.jl
+++ b/src/strongwolfe.jl
@@ -211,10 +211,13 @@ end
 function interpolate(a_i1::Real, a_i::Real,
                      ϕ_a_i1::Real, ϕ_a_i::Real,
                      dϕ_a_i1::Real, dϕ_a_i::Real)
-    d1 = dϕ_a_i1 + dϕ_a_i -
-        3 * (ϕ_a_i1 - ϕ_a_i) / (a_i1 - a_i)
-    d2 = sqrt(d1 * d1 - dϕ_a_i1 * dϕ_a_i)
-    return a_i - (a_i - a_i1) *
+    d1, d2 = cubic_d1_d2(a_i1, ϕ_a_i1, dϕ_a_i1, a_i, ϕ_a_i, dϕ_a_i)
+    # Unlike the cubic in backtracking.jl, this numerator does not cancel, so
+    # rewriting it through its conjugate would cost accuracy rather than gain it
+    a_j = a_i - (a_i - a_i1) *
         ((dϕ_a_i + d2 - d1) /
          (dϕ_a_i - dϕ_a_i1 + 2 * d2))
+    # A vanishing denominator or a degenerate cubic can leave the bracket
+    lo, hi = minmax(a_i1, a_i)
+    return lo < a_j < hi ? a_j : (a_i1 + a_i) / 2
 end

--- a/src/strongwolfe.jl
+++ b/src/strongwolfe.jl
@@ -82,37 +82,28 @@ function (ls::StrongWolfe)(ϕ, dϕ, ϕdϕ,
     end
 
     # Step-sizes
-    a_0 = zero(T)
-    a_iminus1 = a_0
+    a_iminus1 = zero(T)
     a_i = alpha0
     a_max = convert(T, 65536)
 
-    # ϕ(alpha) = df.f(x + alpha * p)
-    ϕ_a_iminus1 = ϕ_0
-    ϕ_a_i = convert(T, NaN)
-
-    # ϕ'(alpha) = dot(g(x + alpha * p), p)
-    dϕ_a_i = convert(T, NaN)
+    # ϕ(alpha) = df.f(x + alpha * p) and ϕ'(alpha) = dot(g(x + alpha * p), p) at
+    # a_{i - 1}, which is the endpoint zoom brackets against
+    ϕ_a_iminus1, dϕ_a_iminus1 = ϕ_0, dϕ_0
 
     # Iteration counter
     i = 1
 
     while a_i < a_max
-        ϕ_a_i = ϕ(a_i)
-        pushcache!(cache, a_i, ϕ_a_i)
+        # Both zoom and the curvature test below need the slope, so fuse the two
+        ϕ_a_i, dϕ_a_i = ϕdϕ(a_i)
+        pushcache!(cache, a_i, ϕ_a_i, dϕ_a_i)
 
         # Test Wolfe conditions
         if (ϕ_a_i > ϕ_0 + c_1 * a_i * dϕ_0) ||
             (ϕ_a_i >= ϕ_a_iminus1 && i > 1)
-            a_star = zoom(a_iminus1, a_i,
-                          dϕ_0, ϕ_0,
-                          ϕdϕ, cache, c_1, c_2)
-            return a_star, ϕ(a_star)
-        end
-
-        dϕ_a_i = dϕ(a_i)
-        if !isnothing(cache)
-            push!(cache.slopes, dϕ_a_i)
+            return zoom(a_iminus1, ϕ_a_iminus1, dϕ_a_iminus1,
+                        a_i, ϕ_a_i, dϕ_a_i,
+                        dϕ_0, ϕ_0, ϕdϕ, cache, c_1, c_2)
         end
 
         # Check condition 2
@@ -121,18 +112,15 @@ function (ls::StrongWolfe)(ϕ, dϕ, ϕdϕ,
         end
 
         # Check condition 3
-        if dϕ_a_i >= zero(T) # FIXME untested!
-            a_star = zoom(a_i, a_iminus1,
-                          dϕ_0, ϕ_0, ϕdϕ, cache, c_1, c_2)
-            return a_star, ϕ(a_star)
+        if dϕ_a_i >= zero(T)
+            return zoom(a_i, ϕ_a_i, dϕ_a_i,
+                        a_iminus1, ϕ_a_iminus1, dϕ_a_iminus1,
+                        dϕ_0, ϕ_0, ϕdϕ, cache, c_1, c_2)
         end
 
         # Choose a_iplus1 from the interval (a_i, a_max)
-        a_iminus1 = a_i
+        a_iminus1, ϕ_a_iminus1, dϕ_a_iminus1 = a_i, ϕ_a_i, dϕ_a_i
         a_i *= ρ
-
-        # Update ϕ_a_iminus1
-        ϕ_a_iminus1 = ϕ_a_i
 
         # Update iteration count
         i += 1
@@ -141,8 +129,10 @@ function (ls::StrongWolfe)(ϕ, dϕ, ϕdϕ,
     throw(LineSearchException("StrongWolfe: bracketing reached a_max=$a_max without satisfying Wolfe conditions.", a_max))
 end
 
-function zoom(a_lo::T,
-              a_hi::T,
+# The caller has evaluated both endpoints, and they are only ever reassigned to
+# already-evaluated points, so no endpoint is ever recomputed here.
+function zoom(a_lo::T, ϕ_a_lo::Real, ϕprime_a_lo::Real,
+              a_hi::T, ϕ_a_hi::Real, ϕprime_a_hi::Real,
               dϕ_0::Real,
               ϕ_0::Real,
               ϕdϕ,
@@ -152,14 +142,6 @@ function zoom(a_lo::T,
 
     # Step-size
     a_j = convert(T, NaN)
-
-    # The endpoints are only ever reassigned to already-evaluated points, so their
-    # values and slopes are carried through the loop rather than recomputed.
-    ϕ_a_lo, ϕprime_a_lo = ϕdϕ(a_lo)
-    pushcache!(cache, a_lo, ϕ_a_lo, ϕprime_a_lo)
-
-    ϕ_a_hi, ϕprime_a_hi = ϕdϕ(a_hi)
-    pushcache!(cache, a_hi, ϕ_a_hi, ϕprime_a_hi)
 
     # Count iterations
     iteration = 0
@@ -191,7 +173,7 @@ function zoom(a_lo::T,
             a_hi, ϕ_a_hi, ϕprime_a_hi = a_j, ϕ_a_j, ϕprime_a_j
         else
             if abs(ϕprime_a_j) <= -c_2 * dϕ_0
-                return a_j
+                return a_j, ϕ_a_j
             end
 
             # Reads the bracket width before a_lo moves below

--- a/src/strongwolfe.jl
+++ b/src/strongwolfe.jl
@@ -21,7 +21,23 @@ This algorithm is mostly of theoretical interest; users should most likely use
     c_2::T = 0.9
     ρ::T = 2.0
     cache::Union{Nothing,LineSearchCache{T}} = nothing
+
+    function StrongWolfe{T}(c_1, c_2, ρ, cache) where T
+        if !(0 < c_1 < c_2 < 1)
+            throw(ArgumentError(
+                LazyString("The Wolfe constants must satisfy 0 < c_1 < c_2 < 1. Got c_1 = ", c_1, " and c_2 = ", c_2),
+            ))
+        end
+        if !(ρ > 1)
+            throw(ArgumentError(
+                LazyString("The bracket growth factor must be larger than one, otherwise bracketing never terminates. Got ρ = ", ρ),
+            ))
+        end
+        return new{T}(c_1, c_2, ρ, cache)
+    end
 end
+StrongWolfe(c_1::T, c_2::T, ρ::T, cache::Union{Nothing,LineSearchCache{T}}) where T =
+    StrongWolfe{T}(c_1, c_2, ρ, cache)
 
 """
     (ls::StrongWolfe)(df, x::AbstractArray, p::AbstractArray, alpha0::Real, x_new, ϕ_0, dϕ_0) -> alpha, ϕalpha
@@ -56,6 +72,14 @@ function (ls::StrongWolfe)(ϕ, dϕ, ϕdϕ,
     emptycache!(cache)
 
     pushcache!(cache, zero(T), ϕ_0, dϕ_0)
+
+    if !(isfinite(ϕ_0) && isfinite(dϕ_0))
+        throw(LineSearchException("Value and slope at step length = 0 must be finite.", zero(T)))
+    end
+    # dϕ_0 == 0 is accepted: Armijo then reduces to a plain decrease test
+    if dϕ_0 > zero(T)
+        throw(LineSearchException("Search direction is not a direction of descent.", zero(T)))
+    end
 
     # Step-sizes
     a_0 = zero(T)

--- a/src/strongwolfe.jl
+++ b/src/strongwolfe.jl
@@ -51,23 +51,24 @@ See the one-dimensional method for additional details.
 function (ls::StrongWolfe)(df, x::AbstractArray{T},
                            p::AbstractArray{T}, α::Real, x_new::AbstractArray{T},
                            ϕ_0, dϕ_0) where T
-    ϕ, dϕ, ϕdϕ = make_ϕ_dϕ_ϕdϕ(df, x_new, x, p)
-    ls(ϕ, dϕ, ϕdϕ, α, ϕ_0, dϕ_0)
+    ϕdϕ = make_ϕdϕ(df, x_new, x, p)
+    ls(ϕdϕ, α, ϕ_0, dϕ_0)
 end
 
-"""
-    (ls::StrongWolfe)(ϕ, dϕ, ϕdϕ, alpha0, ϕ_0, dϕ_0) -> alpha, ϕalpha
+(ls::StrongWolfe)(ϕ, dϕ, ϕdϕ, alpha0, ϕ_0, dϕ_0) = ls(ϕdϕ, alpha0, ϕ_0, dϕ_0)
 
-Given `ϕ(alpha::Real)`, its derivative `dϕ`, a combined-evaluation function
-`ϕdϕ(alpha) -> (ϕ(alpha), dϕ(alpha))`, and an initial guess `alpha0`,
-identify a value of `alpha > 0` satisfying the strong Wolfe conditions.
+"""
+    (ls::StrongWolfe)(ϕdϕ, alpha0, ϕ_0, dϕ_0) -> alpha, ϕalpha
+
+Given a combined-evaluation function `ϕdϕ(alpha) -> (ϕ(alpha), dϕ(alpha))` and an
+initial guess `alpha0`, identify a value of `alpha > 0` satisfying the strong Wolfe
+conditions.
 
 `ϕ_0` and `dϕ_0` are the value and derivative, respectively, of `ϕ` at `alpha = 0.`
 
 Both `alpha` and `ϕ(alpha)` are returned.
 """
-function (ls::StrongWolfe)(ϕ, dϕ, ϕdϕ,
-                           alpha0::T, ϕ_0, dϕ_0) where T<:Real
+function (ls::StrongWolfe)(ϕdϕ, alpha0::T, ϕ_0, dϕ_0) where T<:Real
     (; c_1, c_2, ρ, cache) = ls
     emptycache!(cache)
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -3,6 +3,9 @@ struct LineSearchException{T<:Real} <: Exception
     alpha::T
 end
 
+Base.showerror(io::IO, e::LineSearchException) =
+    print(io, "LineSearchException: ", e.message, " Step length: ", e.alpha)
+
 abstract type AbstractLineSearch end
 
 # For debugging

--- a/test/captured.jl
+++ b/test/captured.jl
@@ -31,6 +31,25 @@ end
     end
 end
 
+# Each cached value must belong to the α stored beside it
+@testset "Cached α and value agree" begin
+    ϕ(x) = (x - π)^4
+    dϕ(x) = 4*(x-π)^3
+    ϕdϕ(x) = (ϕ(x), dϕ(x))
+
+    @testset "$(nameof(LS))" for LS in (HagerZhang, StrongWolfe, MoreThuente, BackTracking)
+        cache = LineSearchCache{Float64}()
+        LS(; cache)(ϕ, dϕ, ϕdϕ, 10.0, ϕ(0), dϕ(0))
+        @test all(v == ϕ(α) for (α, v) in zip(cache.alphas, cache.values))
+    end
+
+    # ψ is NaN above 4, so BackTracking leaves the initial step before caching a value
+    ψ(x) = x > 4 ? NaN : (x - 1.0)^2
+    cache = LineSearchCache{Float64}()
+    BackTracking(; cache)(ψ, 8.0, ψ(0.0), -2.0)
+    @test all(v === ψ(α) for (α, v) in zip(cache.alphas, cache.values))
+end
+
 # From PR#174
 @testset "PR#174" begin
     tc = LineSearchTestCase(

--- a/test/captured.jl
+++ b/test/captured.jl
@@ -1,4 +1,5 @@
 using LineSearches
+using NaNMath
 using NLSolversBase
 using Test
 
@@ -153,6 +154,15 @@ end
             phi_lim, phi_0, dphi_0, delta, sigma,
         )
         @test !wolfe  # normal exit, not Wolfe
+    end
+
+    @testset "bisect! stores non-finite values" begin
+        # `argmin` ranks NaN below every float, so the failure path cannot use it
+        alphas, values, slopes = [0.0, 1.0], [0.0, 5.0], [-2.0, -0.5]
+        LineSearches.bisect!(d -> (NaN, NaN), alphas, values, slopes, 1, 2,
+                             1e-6, 0.0, -2.0, 0.1, 0.9)
+        @test isnan(values[argmin(values)])
+        @test alphas[last(NaNMath.findmin(values))] == 0.0
     end
 
     @testset "Wolfe during bracket expansion" begin

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -1,0 +1,40 @@
+@testset "Invalid parameters" begin
+    @test_throws "ArgumentError: The Armijo constant must satisfy 0 < c_1 < 1. Got c_1 = 0.0" BackTracking(; c_1 = 0.0)
+    @test_throws "ArgumentError: The Armijo constant must satisfy 0 < c_1 < 1. Got c_1 = 1.0" BackTracking(; c_1 = 1.0)
+    @test_throws "ArgumentError: The backtracking factors must satisfy 0 < ρ_lo <= ρ_hi < 1. Got ρ_lo = 0.9 and ρ_hi = 0.5" BackTracking(; ρ_lo = 0.9, ρ_hi = 0.5)
+    @test_throws "ArgumentError: The backtracking factors must satisfy 0 < ρ_lo <= ρ_hi < 1. Got ρ_lo = 0.1 and ρ_hi = 1.0" BackTracking(; ρ_hi = 1.0)
+    @test_throws "ArgumentError: The interpolation order must be 2 or 3. Got order = 4" BackTracking(; order = 4)
+    @test_throws "ArgumentError: The iteration limit must be positive. Got iterations = 0" BackTracking(; iterations = 0)
+    @test_throws "ArgumentError: The maximum step length must be positive. Got maxstep = 0.0" BackTracking(; maxstep = 0.0)
+
+    @test_throws "ArgumentError: The Wolfe constants must satisfy 0 < c_1 < c_2 < 1. Got c_1 = 0.9 and c_2 = 0.1" StrongWolfe(; c_1 = 0.9, c_2 = 0.1)
+    @test_throws "ArgumentError: The Wolfe constants must satisfy 0 < c_1 < c_2 < 1. Got c_1 = 0.0001 and c_2 = 1.0" StrongWolfe(; c_2 = 1.0)
+    # ρ = 1 leaves the bracket the same width forever
+    @test_throws "ArgumentError: The bracket growth factor must be larger than one, otherwise bracketing never terminates. Got ρ = 1.0" StrongWolfe(; ρ = 1.0)
+end
+
+@testset "Invalid endpoints" begin
+    ϕ(α) = (α - 1.0)^2
+    dϕ(α) = 2 * (α - 1.0)
+    ϕdϕ(α) = (ϕ(α), dϕ(α))
+
+    @testset "$(nameof(typeof(ls)))" for ls in (BackTracking(), StrongWolfe(),
+                                                MoreThuente(), HagerZhang())
+        msg = "LineSearchException: Value and slope at step length = 0 must be finite. Step length: 0.0"
+        @test_throws msg ls(ϕ, dϕ, ϕdϕ, 1.0, NaN, -2.0)
+        @test_throws msg ls(ϕ, dϕ, ϕdϕ, 1.0, 1.0, NaN)
+
+        # An ascent direction can never satisfy sufficient decrease
+        @test_throws "LineSearchException: Search direction is not a direction of descent. Step length: 0.0" ls(
+            α -> 1.0 + α, α -> 1.0, α -> (1.0 + α, 1.0), 1.0, 1.0, 1.0)
+    end
+
+    # BackTracking still accepts a zero slope, where Armijo is a plain decrease test
+    @test BackTracking()(ϕ, dϕ, ϕdϕ, 1.0, ϕ(0.0), 0.0) == (1.0, ϕ(1.0))
+end
+
+# The step length these report is whatever the halving loop reached, so match a prefix
+@testset "No finite value" begin
+    @test_throws r"^LineSearchException: Static: failed to achieve finite new evaluation point\." Static()(α -> NaN, 1.0)
+    @test_throws r"^LineSearchException: Backtracking: failed to achieve finite new evaluation point\." BackTracking()(α -> NaN, 1.0, 1.0, -1.0)
+end

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -33,6 +33,12 @@ end
     @test BackTracking()(ϕ, dϕ, ϕdϕ, 1.0, ϕ(0.0), 0.0) == (1.0, ϕ(1.0))
 end
 
+@testset "cstep outside its bracket" begin
+    # An internal invariant, so it reports like the rest of the package
+    @test_throws "LineSearchException: MoreThuente: cstep called with alpha = 3.0 outside the bracket [0.0, 2.0]. Step length: 3.0" LineSearches.cstep(
+        0.0, 1.0, -1.0, 2.0, 0.5, 0.2, 3.0, 0.4, 0.1, true, 0.0, 10.0)
+end
+
 # The step length these report is whatever the halving loop reached, so match a prefix
 @testset "No finite value" begin
     @test_throws r"^LineSearchException: Static: failed to achieve finite new evaluation point\." Static()(α -> NaN, 1.0)

--- a/test/evalcounts.jl
+++ b/test/evalcounts.jl
@@ -47,14 +47,16 @@
     ψ(α) = -α / (1 + 10α^2) + 0.02α^2
     dψ(α) = -(1 - 10α^2) / (1 + 10α^2)^2 + 0.04α
 
-    # zoom reassigns its endpoints only to already-evaluated points, so it costs 2
-    # evaluations to seed the bracket plus 1 per iteration (was ~4 per iteration).
+    # The caller supplies both endpoints and zoom only ever reassigns them to
+    # already-evaluated points, so it costs exactly 1 evaluation per iteration.
     @testset "zoom, c_2=$c_2" for (c_2, entries, expected) in
-            ((0.5, 3, 0.412201859), (0.1, 4, 0.3461435202), (0.01, 7, 0.312411912))
+            ((0.5, 1, 0.412201859), (0.1, 2, 0.3461435202), (0.01, 5, 0.312411912))
         n = Ref(0)
         ϕdϕ = α -> (n[] += 1; (ψ(α), dψ(α)))
-        a = LineSearches.zoom(0.0, 1.0, dψ(0.0), ψ(0.0), ϕdϕ, nothing, 1e-4, c_2)
+        a, val = LineSearches.zoom(0.0, ψ(0.0), dψ(0.0), 1.0, ψ(1.0), dψ(1.0),
+                                   dψ(0.0), ψ(0.0), ϕdϕ, nothing, 1e-4, c_2)
         @test a ≈ expected
+        @test val == ψ(a)
         @test n[] == entries
     end
 

--- a/test/evalcounts.jl
+++ b/test/evalcounts.jl
@@ -66,14 +66,17 @@
         @test val ≈ ψ(α)
     end
 
-    # HagerZhang stores every evaluated point, so it should never ask for the same α twice
+    # Each carries the points it has already seen, so none should ask for the same α twice.
+    # `dg` stays uncounted: splitting a point into ϕ and dϕ is by design, recomputing it is not.
     problems = ((ψ, dψ),
                 (α -> (α^2 - 11)^2 + (α - 7)^2, α -> 4α * (α^2 - 11) + 2(α - 7)),
                 (α -> 1 - 1 / (1 + (α - 2)^2), α -> 2(α - 2) / (1 + (α - 2)^2)^2))
-    @testset "HagerZhang evaluates each α once" for (g, dg) in problems,
-                                                    α0 in (0.1, 1.0, 5.0)
+    @testset "$(nameof(typeof(ls))) evaluates each α once" for
+            ls in (HagerZhang(), MoreThuente(), StrongWolfe()),
+            (g, dg) in problems, α0 in (0.1, 1.0, 5.0)
         seen = Float64[]
-        α, val = HagerZhang()(α -> (push!(seen, α); (g(α), dg(α))), α0, g(0.0), dg(0.0))
+        α, val = ls(α -> (push!(seen, α); g(α)), dg,
+                    α -> (push!(seen, α); (g(α), dg(α))), α0, g(0.0), dg(0.0))
         @test allunique(seen)
         @test val ≈ g(α)
     end

--- a/test/evalcounts.jl
+++ b/test/evalcounts.jl
@@ -66,8 +66,8 @@
         @test val ≈ ψ(α)
     end
 
-    # Each carries the points it has already seen, so none should ask for the same α twice.
-    # `dg` stays uncounted: splitting a point into ϕ and dϕ is by design, recomputing it is not.
+    # Each carries the points it has seen, so none should ask for the same α twice.
+    # `dg` is uncounted: splitting a point into ϕ and dϕ is by design, repeating it is not.
     problems = ((ψ, dψ),
                 (α -> (α^2 - 11)^2 + (α - 7)^2, α -> 4α * (α^2 - 11) + 2(α - 7)),
                 (α -> 1 - 1 / (1 + (α - 2)^2), α -> 2(α - 2) / (1 + (α - 2)^2)^2))

--- a/test/qa.jl
+++ b/test/qa.jl
@@ -27,6 +27,7 @@ import JET
             LineSearches;
             ignore = (
                 :RefValue, # Base
+                :findmin, # NaNMath
                 :max, # NaNMath
                 :min, # NaNMath
             ),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ my_tests = [
     "alphacalc.jl",
     "arbitrary_precision.jl",
     "captured.jl",
+    "errors.jl",
     "evalcounts.jl",
     "issues.jl",
     "qa.jl",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ my_tests = [
     "arbitrary_precision.jl",
     "captured.jl",
     "errors.jl",
+    "strongwolfe.jl",
     "evalcounts.jl",
     "issues.jl",
     "qa.jl",

--- a/test/strongwolfe.jl
+++ b/test/strongwolfe.jl
@@ -17,7 +17,9 @@ end
     ϕ(x) = (x - π)^4
     dϕ(x) = 4 * (x - π)^3
 
-    a = LineSearches.zoom(0.0, 1.0, dϕ(0.0), ϕ(0.0), x -> (ϕ(x), dϕ(x)), nothing, 1e-4, 0.9)
+    a, val = LineSearches.zoom(0.0, ϕ(0.0), dϕ(0.0), 1.0, ϕ(1.0), dϕ(1.0),
+                               dϕ(0.0), ϕ(0.0), x -> (ϕ(x), dϕ(x)), nothing, 1e-4, 0.9)
     @test 0 < a < 1
+    @test val == ϕ(a)
     @test abs(dϕ(a)) <= 0.9 * abs(dϕ(0.0))
 end

--- a/test/strongwolfe.jl
+++ b/test/strongwolfe.jl
@@ -1,0 +1,23 @@
+@testset "interpolate" begin
+    interp = LineSearches.interpolate
+
+    # Each of these used to throw, return NaN, or land outside (0.5, 2.0)
+    @test interp(0.5, 2.0, 1.0, 0.0, -1.0, -1.0) == 1.25      # negative radicand
+    @test interp(0.5, 2.0, 1.0, 0.2, -1e160, 1e160) == 1.25   # d1^2 overflows
+    @test interp(0.5, 2.0, 1.0, 0.2, -1e-180, 1e-180) == 1.25 # slope product underflows
+    @test interp(0.5, 2.0, 0.0, 0.0, 0.0, 0.0) == 1.25        # nothing to interpolate
+
+    # Where the cubic is well posed the safeguards cost no accuracy
+    args = (0.0, 1.0, 1.0, 0.2, -3.0, 0.7)
+    @test interp(args...) ≈ Float64(interp(big.(args)...)) rtol = 1e-15
+end
+
+@testset "zoom with same-sign slopes" begin
+    # The first zoom call site brackets on ϕ alone, so both slopes may share a sign
+    ϕ(x) = (x - π)^4
+    dϕ(x) = 4 * (x - π)^3
+
+    a = LineSearches.zoom(0.0, 1.0, dϕ(0.0), ϕ(0.0), x -> (ϕ(x), dϕ(x)), nothing, 1e-4, 0.9)
+    @test 0 < a < 1
+    @test abs(dϕ(a)) <= 0.9 * abs(dϕ(0.0))
+end


### PR DESCRIPTION
#206 audited the split value/derivative helpers and fixed one correctness bug. This is the same audit applied to the rest of the package: `BackTracking`, `HagerZhang`, `StrongWolfe`, `MoreThuente`, `Static` and the initial guesses. `HagerZhangLS` is out of scope.

Every finding was reproduced by running the code. No pinned step length in `test/alphacalc.jl` moves.

## Correctness

**`interpolate` and `cstep` solve the same cubic.** `cstep`'s `theta` is `interpolate`'s `d1` written with the endpoints swapped, which cancels, so the three-line `s`/`sqrt` kernel appeared five times — once in `interpolate`, once in each of `cstep`'s four cases — and only one of the five clamped its radicand at zero. Over 200k random brackets with the second slope's sign left free, as `zoom`'s first call site allows, `interpolate` threw a bare `DomainError` on **4.0%** and silently returned a step **outside its own bracket** on a further **17.5%**. Both are now zero. The shared kernel is verified bit-identical to the four original `cstep` blocks on 475k random inputs, the only divergence being the 4.9% where the old one threw.

The numerator is deliberately left alone: unlike the cubic in `backtracking.jl` it does not cancel, so #206's conjugate rewrite costs accuracy here (1e-17 → 1.9e-3 approaching the degenerate configuration).

**Unchecked inputs.** `BackTracking` and `StrongWolfe` validated nothing. A `NaN` at `alpha = 0` makes the Armijo test false, so `BackTracking` returned the initial step with a `NaN` value; an ascent direction shrank the step until it underflowed and Armijo passed vacuously, returning `alpha ≈ 6e-17`. `HagerZhang` and `MoreThuente` already threw in both cases. `StrongWolfe(ρ = 1.0)` constructed happily and then looped to `a_max`; `StrongWolfe(c_1 = 0.9, c_2 = 0.1)` was accepted. Both now validate in the constructor, as `HagerZhangLS` does.

**Other.** `BackTracking` recorded the initial alpha in its cache beside a different step's value. `Static` returned `NaN` silently. `MoreThuente` had an early return that fired before checking sufficient decrease, so it could accept a step failing Armijo. `LineSearchException` had no `showerror`, so it printed as its constructor call.

## Evaluations saved

Measured over 9 problem × `alpha0` combinations, counting points where the objective value is computed:

| | before | after |
|---|---|---|
| `MoreThuente` | 38 | **29** |
| `StrongWolfe` | 50 | **32** |
| `HagerZhang` | 31 | 31 |

`MoreThuente` evaluated its initial step twice on **every** call — the pre-loop finite-value check and the first pass of the loop, with nothing between them that moves the step.

`StrongWolfe` wasted 3 per search that enters `zoom`: #206 hoisted `zoom`'s endpoint evaluations out of its loop, but they still happened on entry for points the caller already held, and `zoom` returned only a step so both call sites recomputed `ϕ` at a point it had just evaluated.

Allocations: `StrongWolfe` 448 → 96 B, the same floor every method pays to `NLSolversBase`.

## Simplification

`mayterminate[]` was written in ten places and read once, in an `if mayterminate[]; mayterminate[] = false; end` guarding an unconditional assignment. Nothing decides anything on it, so it is consumed once on entry — and unlike before, the early validation throws no longer leave it set.

Dead code in `secant2!`, `bisect!`, `cstep`, `BackTracking` and `Static`. Four occurrences of `isapprox(x, 0; atol = eps(T))` on quantities with units of `f/α`, `f/α³` or a slope, where an absolute machine-epsilon tolerance either never fires or always does.

## Tests

New `test/errors.jl` and `test/strongwolfe.jl`; extended `test/evalcounts.jl` and `test/captured.jl`. The evaluation-count and cache-content tests were committed first, failing, and the later commits turn them green. Error assertions match the full rendered message, not just the exception type, since every validation branch throws the same type.

## Two things I did not do

**`sizehint!` on `HagerZhang`'s three vectors makes it worse, not better.** Measured: 480 B → 576 at capacity 8, 768 at 16, **1632** at `linesearchmax`. A typical search stores 2 to 6 points, so reserving capacity costs more than the reallocations it avoids. Passing a `cache` already brings it to 96 B.

**`HagerZhang`'s `argmin` over `values` is hardening, not a fixed bug.** `bisect!` does store non-finite values and `argmin` does rank `NaN` below every float, but 60k randomised searches over `NaN`-valued regions all recovered during bracketing, so I could not drive it end to end.

I also left `satisfies_wolfe`'s parameters threaded through `secant2!`, `update!` and `bisect!` as they are. Collecting them in a struct would cut three 12-argument signatures to about 7, but it is a large mechanical diff across the most intricate code here for no behavioural gain. I did take the small half: `secant2!` was the only place assuming `alphas[1]` is the `alpha = 0` point.

## Verification

- Full suite green, including Aqua, ExplicitImports and JET.
- Pinned step lengths in `test/alphacalc.jl` bit-identical.
- 2000 random degree-6 polynomials × 2 initial steps × 5 configurations: no repeated step, no Armijo violations, no unexpected exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

