### PR TITLE
Return the vetted point in x_new

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LineSearches"
 uuid = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
-version = "7.7.2"
+version = "7.8.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/src/reference/linesearch.md
+++ b/docs/src/reference/linesearch.md
@@ -5,6 +5,7 @@ DocTestSetup = :(using LineSearches)
 # Line search routines
 
 ```@docs
+AbstractLineSearch
 BackTracking
 HagerZhang
 MoreThuente

--- a/src/LineSearches.jl
+++ b/src/LineSearches.jl
@@ -13,10 +13,15 @@ export InitialHagerZhang, InitialStatic, InitialPrevious,
     InitialQuadratic, InitialConstantChange
 
 
+# Move a distance of alpha in the direction of s
+function set_x_new!(x_new, x, s, α)
+    x_new .= muladd.(α, s, x)
+    return x_new
+end
+
 function make_ϕ(df, x_new, x, s)
     function ϕ(α)
-        # Move a distance of alpha in the direction of s
-        x_new .= muladd.(α, s, x)
+        set_x_new!(x_new, x, s, α)
 
         # Evaluate f(x+α*s)
         return NLSolversBase.value!(df, x_new)
@@ -25,8 +30,7 @@ function make_ϕ(df, x_new, x, s)
 end
 function make_ϕdϕ(df, x_new, x, s)
     function ϕdϕ(α)
-        # Move a distance of alpha in the direction of s
-        x_new .= muladd.(α, s, x)
+        set_x_new!(x_new, x, s, α)
         # Calculate ϕ(a_i), ϕ'(a_i)
         ϕ, dϕ = NLSolversBase.value_jvp!(df, x_new, s)
         return ϕ, real(dϕ)
@@ -35,8 +39,7 @@ function make_ϕdϕ(df, x_new, x, s)
 end
 function make_dϕ(df, x_new, x, s)
     function dϕ(α)
-        # Move a distance of alpha in the direction of s
-        x_new .= muladd.(α, s, x)
+        set_x_new!(x_new, x, s, α)
         # Calculate ϕ'(a_i)
         return real(NLSolversBase.jvp!(df, x_new, s))
     end

--- a/src/backtracking.jl
+++ b/src/backtracking.jl
@@ -61,7 +61,9 @@ function (ls::BackTracking)(df::AbstractObjective, x::AbstractArray{T}, s::Abstr
     end
 
     α_0 = min(α_0, min(alphamax, ls.maxstep / norm(s, Inf)))
-    ls(ϕ, α_0, ϕ_0, dϕ_0)
+    α, ϕα = ls(ϕ, α_0, ϕ_0, dϕ_0)
+    set_x_new!(x_new, x, s, α)
+    return α, ϕα
 end
 
 (ls::BackTracking)(ϕ, dϕ, ϕdϕ, αinitial, ϕ_0, dϕ_0) = ls(ϕ, αinitial, ϕ_0, dϕ_0)

--- a/src/hagerzhang.jl
+++ b/src/hagerzhang.jl
@@ -105,7 +105,9 @@ function (ls::HagerZhang)(df::AbstractObjective, x::AbstractArray{T},
                           s::AbstractArray{T}, α::Real,
                           x_new::AbstractArray{T}, phi_0::Real, dphi_0::Real) where T
     ϕdϕ = make_ϕdϕ(df, x_new, x, s)
-    ls(ϕdϕ, α, phi_0, dphi_0)
+    α_star, ϕ_star = ls(ϕdϕ, α, phi_0, dphi_0)
+    set_x_new!(x_new, x, s, α_star)
+    return α_star, ϕ_star
 end
 
 (ls::HagerZhang)(ϕ, dϕ, ϕdϕ, c, phi_0, dphi_0) = ls(ϕdϕ, c, phi_0, dphi_0)

--- a/src/hagerzhangls.jl
+++ b/src/hagerzhangls.jl
@@ -437,5 +437,7 @@ function (ls::HagerZhangLS)(df::AbstractObjective, x::AbstractArray{T},
     elseif isnothing(dϕ_0)
         dϕ_0 = dϕ(real(T)(0))
     end
-    ls(ϕdϕ, α, ϕ_0, dϕ_0)
+    α_star, ϕ_star = ls(ϕdϕ, α, ϕ_0, dϕ_0)
+    set_x_new!(x_new, x, s, α_star)
+    return α_star, ϕ_star
 end

--- a/src/morethuente.jl
+++ b/src/morethuente.jl
@@ -156,7 +156,9 @@ function (ls::MoreThuente)(df::AbstractObjective, x::AbstractArray{T},
                            s::AbstractArray{T}, alpha::Real, x_new::AbstractArray{T},
                            ϕ_0, dϕ_0) where T
     ϕdϕ = make_ϕdϕ(df, x_new, x, s)
-    ls(ϕdϕ, alpha, ϕ_0, dϕ_0)
+    α, ϕα = ls(ϕdϕ, alpha, ϕ_0, dϕ_0)
+    set_x_new!(x_new, x, s, α)
+    return α, ϕα
 end
 
 (ls::MoreThuente)(ϕ, dϕ, ϕdϕ, alpha, ϕ_0, dϕ_0) = ls(ϕdϕ, alpha, ϕ_0, dϕ_0)

--- a/src/static.jl
+++ b/src/static.jl
@@ -11,7 +11,9 @@ struct Static <: AbstractLineSearch end
 
 function (ls::Static)(df::AbstractObjective, x, s, α, x_new = similar(x), ϕ_0 = nothing, dϕ_0 = nothing)
     ϕ = make_ϕ(df, x_new, x, s)
-    ls(ϕ, α)
+    α_star, ϕα = ls(ϕ, α)
+    set_x_new!(x_new, x, s, α_star)
+    return α_star, ϕα
 end
 
 (ls::Static)(ϕ, dϕ, ϕdϕ, α, ϕ_0, dϕ_0) = ls(ϕ, α)

--- a/src/strongwolfe.jl
+++ b/src/strongwolfe.jl
@@ -52,7 +52,9 @@ function (ls::StrongWolfe)(df, x::AbstractArray{T},
                            p::AbstractArray{T}, α::Real, x_new::AbstractArray{T},
                            ϕ_0, dϕ_0) where T
     ϕdϕ = make_ϕdϕ(df, x_new, x, p)
-    ls(ϕdϕ, α, ϕ_0, dϕ_0)
+    α_star, ϕα = ls(ϕdϕ, α, ϕ_0, dϕ_0)
+    set_x_new!(x_new, x, p, α_star)
+    return α_star, ϕα
 end
 
 (ls::StrongWolfe)(ϕ, dϕ, ϕdϕ, alpha0, ϕ_0, dϕ_0) = ls(ϕdϕ, alpha0, ϕ_0, dϕ_0)

--- a/src/types.jl
+++ b/src/types.jl
@@ -6,6 +6,19 @@ end
 Base.showerror(io::IO, e::LineSearchException) =
     print(io, "LineSearchException: ", e.message, " Step length: ", e.alpha)
 
+"""
+    AbstractLineSearch
+
+Supertype of the line search algorithms.
+
+Every algorithm can be called as
+
+    (ls::AbstractLineSearch)(df, x, s, α_0, x_new, ϕ_0, dϕ_0) -> (α, ϕ(α))
+
+where `df` is an `NLSolversBase.AbstractObjective`. On return, `x_new` holds
+`x + α*s` for the returned `α`. Callers should use it instead of recomputing the
+step, which would round differently and discard the cached evaluations there.
+"""
 abstract type AbstractLineSearch end
 
 # For debugging

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,7 @@ my_tests = [
     "errors.jl",
     "strongwolfe.jl",
     "evalcounts.jl",
+    "xnew.jl",
     "issues.jl",
     "qa.jl",
 ]

--- a/test/xnew.jl
+++ b/test/xnew.jl
@@ -1,0 +1,22 @@
+@testset "x_new" begin
+    # On return, `x_new` must hold `x + α*s` for the returned α, so callers can
+    # adopt that exact point instead of recomputing it.
+    quadratic = (x = [-1.0, -1.0], f = x -> dot(x, x), g! = (out, x) -> out .= 2 .* x)
+    himmelblau = let pr = OptimTestProblems.UnconstrainedProblems.examples["Himmelblau"]
+        (x = copy(pr.initial_x), f = pr.f, g! = pr.g!)
+    end
+
+    @testset "$(typeof(ls)), $name" for ls in lstypes,
+        (name, pr) in (("quadratic", quadratic), ("Himmelblau", himmelblau))
+
+        (; x, f, g!) = pr
+        df = NLSolversBase.OnceDifferentiable(f, g!, x)
+        ϕ_0, g_0 = NLSolversBase.value_gradient!(df, x)
+        s = -g_0
+        x_new = similar(x)
+
+        α, _ = ls(df, x, s, 1.0, x_new, ϕ_0, dot(s, g_0))
+
+        @test x_new == muladd.(α, s, x)
+    end
+end


### PR DESCRIPTION
> Reopens #208, which was merged as `0ada9b3` and then reverted by #209 so that #206 and
> #207 could land first. This is the same change rebased on top of them: `HagerZhang`,
> `HagerZhangLS`, `MoreThuente` and `StrongWolfe` now wrap the `ϕdϕ`-only call methods
> those PRs introduced, the per-step assignment moved into #207's `make_dϕ`, and the
> version bump is 7.7.2 → 7.8.0. The one deletion relative to #208 is the
> `mayterminate[] = false` that `test/xnew.jl` needed before calling `HagerZhang`, now
> that #207 has `HagerZhang` consume the flag on entry. Otherwise identical to what was
> reviewed there.

---

Every `df::AbstractObjective` method builds its closures with

```julia
x_new .= muladd.(α, s, x)
```

so `x_new` is written on every trial evaluation, and on return it holds whichever step
happened to be evaluated last. Usually that is the accepted step — but only by
coincidence, and two `HagerZhang` return sites break the coincidence:

```julia
if b - a <= eps(b)
    return a, values[ia]          # hagerzhang.jl:307, a stored bracket endpoint
...
        return A, values[iA]      # :328, the check_flatness branch
```

Both hand back an α evaluated earlier in the loop, while `x_new` still holds whatever
`secant2!` or the bisection branch evaluated last — a whole trial step away from the
returned α.

Even where the coincidence holds, a caller has no way to know it and must recompute
`x + α*s` itself, which is not the same point: `muladd` rounds once where a separate
multiply and add round twice, so the two differ in the last ulp of roughly a quarter of
the components (46577 of 200000 in a random sample). Past a handful of dimensions
essentially every step lands on a neighbour of the point that was examined, and then

* the value stored alongside the iterate belongs to a different point, so the sufficient
  decrease that was granted holds one rounding away from the iterate;
* `NLSolversBase` sees a cache miss and re-evaluates the objective, at a point no line
  search condition was ever checked at;
* a point one ulp past a feasibility boundary is simply infeasible, so the caller can get
  a non-finite value or gradient from a step this package certified as finite.

So this makes it a contract rather than a coincidence: on return from a
`df::AbstractObjective` method, `x_new` holds `x + α*s` for the returned α.

```julia
    α, ϕα = ls(ϕ, α_0, ϕ_0, dϕ_0)
    set_x_new!(x_new, x, s, α)
    return α, ϕα
```

`set_x_new!` is shared with the closures, so the restored point is bit-identical to the
one that was evaluated, and it is a plain axpy — no objective evaluation is added. It also
covers the two `HagerZhang` sites above without touching any of its eight return
statements.

`x_new` is an output buffer, so there is no signature change and nothing becomes breaking.
But the two sites above do return a different `x_new` than before, so this is a minor
version bump; downstream callers that want to rely on the contract should bound on 7.8.

The contract is documented on `AbstractLineSearch`, which is now included in the docs, and
`test/xnew.jl` asserts `x_new == muladd.(α, s, x)` on return for every algorithm on two
problems.

## Context

This is a prerequisite for #184 rather than a fix for it. A caller can only be handed a
point whose derivatives have been checked if it is handed the point that was checked; the
remaining gap there is that a JVP is a projection, so a finite `dϕ` does not imply a
finite gradient.

Downstream: JuliaNLSolvers/Optim.jl#1283 adopts `x_new` instead of recomputing the step.
On extended Rosenbrock (n = 20) that cuts BFGS from 316 objective calls to 249, and Newton
from 53 to 49.
