### PR TITLE
Keep HagerZhang's bracket from narrowing onto its own endpoint

### DIFF
--- a/src/hagerzhang.jl
+++ b/src/hagerzhang.jl
@@ -514,8 +514,10 @@ function update!(ϕdϕ,
                 ", phi_c = ", phi_c,
                 ", dphi_c = ", dphi_c)
     end
-    if c < a || c > b
-        return ia, ib, false  # it's out of the bracketing interval
+    # Only a `c` strictly inside can narrow the bracket. On an endpoint, or non-finite,
+    # the returns below would give back a zero-width interval.
+    if !(a < c < b)
+        return ia, ib, false
     end
     if dphi_c >= zero(T)
         return ia, ic, false  # replace b with a closer point

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -39,6 +39,24 @@ end
         0.0, 1.0, -1.0, 2.0, 0.5, 0.2, 3.0, 0.4, 0.1, true, 0.0, 10.0)
 end
 
+# HagerZhang asserts alphas[iB] > alphas[iA] on what secant2! returns, so update! must
+# not narrow a bracket onto one of its own endpoints. It picks between narrowing to c
+# and keeping the bracket using a fresh evaluation at c, which can disagree with the
+# stored slope or value there.
+@testset "update! keeps a bracket of positive width" begin
+    unused(α) = error("ϕdϕ must not be called on these branches")
+    @testset "c = $(alphas[3])" for (alphas, values, slopes) in (
+        ([0.0, 1.0, 0.0], [0.0, 0.5, 0.0], [-1.0, 0.5, 0.25]),      # on the lower end
+        ([0.0, 1.0, 1.0], [0.0, 2.0, -0.5], [-1.0, -0.25, -0.25]),  # on the upper end
+        ([0.0, 1.0, NaN], [0.0, 2.0, -0.5], [-1.0, -0.25, -0.25]),  # not finite
+    )
+        iA, iB, _ = LineSearches.update!(unused, alphas, values, slopes, 1, 2, 3, 0.0,
+                                         0.0, -1.0, LineSearches.DEFAULTDELTA,
+                                         LineSearches.DEFAULTSIGMA)
+        @test (alphas[iA], alphas[iB]) == (0.0, 1.0)
+    end
+end
+
 # The step length these report is whatever the halving loop reached, so match a prefix
 @testset "No finite value" begin
     @test_throws r"^LineSearchException: Static: failed to achieve finite new evaluation point\." Static()(α -> NaN, 1.0)


### PR DESCRIPTION
Fixes #211.

## The defect

`update!` classifies the trial point with `c < a || c > b`, so a `c` sitting exactly *on* an endpoint counts as interior. Both escapes below that guard then hand the endpoint back as the bracket's *other* end:

- `c == a` with `dphi_c >= 0` → `return ia, ic`, and `alphas[ic] == alphas[ia]`
- `c == b` with `phi_c <= phi_lim` → `return ic, ib`, and `alphas[ic] == alphas[ib]`

The caller reads those indices back and asserts `B > A`, which is how this surfaced:

```
AssertionError: B > A
  [1] (::LineSearches.HagerZhang{Float64, Base.RefValue{Bool}})(…)
    @ LineSearches ~/.julia/packages/LineSearches/XbZJE/src/hagerzhang.jl:313
  [3] perform_linesearch!(state::Optim.BFGSState{…}, method::Optim.BFGS{InitialStatic{…}, HagerZhang{…}, …}, …)
```

A non-finite `c` falls through the same guard, since `NaN < a` and `NaN > b` are both false. It reaches the `bisect!(ia, ic)` tail, whose own `@assert b > a` then fails instead.

The entry assertions `slopes[ia] < 0`, `values[ia] <= phi_lim` and `b > a` all hold going in, so the bracket handed to `update!` is well-formed and it is `update!` that degenerates it.

## How it is reached

Which escape fires is decided by a *fresh* evaluation at `c`, so getting there needs the stored slope or value at that endpoint to disagree with what `ϕdϕ` returns there. For `ia == 1` that is ordinary rather than pathological: `secant2!` keeps `slopes[1] = dphi_0`, and `Optim.perform_linesearch!` computes that as `dot(state.g_x, state.s)` while the `ϕdϕ` it passes takes its slopes from `NLSolversBase.value_jvp!`. On an objective that supplies its own `fjvp` those are two independent implementations of one derivative.

Measured over all 47 line searches of a 16-parameter marginal-likelihood fit under `BFGS(linesearch = HagerZhang(rho = 2.0), initial_stepnorm = 1.0)`, using `NLSolversBase.gradient!!` and `jvp!!` so that none of it is a cache hit: two `jvp!!` calls at the same `x` agree 47/47, two `gradient!!` calls agree 47/47, and `dphi_0` matches a forced fresh `dot(gradient!!(obj, x), s)` 47/47 — while that gradient contraction and `jvp!!(obj, x, s)` differ 47/47, by up to `4.7e-3` absolute and **20.4 % relative**. So both routes are individually deterministic and nothing is stale; the gap is only the two implementations. It grows as the slope shrinks, because `dot(g, s)` cancels across the components where a pushforward does not, so it is worst exactly where the line search is most delicate, and far enough into convergence the two can differ in sign. Raised separately as JuliaNLSolvers/Optim.jl#1284; this PR is the robustness half, which is worth having either way since a line search should not assert on it.

`c` then only has to round onto the endpoint. With `a == 0`, `secant(a, b, dphi_a, dphi_b) = -b * dphi_a / (dphi_b - dphi_a)`, which rounds to `0` once `|dphi_a|` is negligible against `dphi_b`.

## The change

Require `c` to be strictly interior. One condition covers the endpoints and the non-finite case, and it makes `bisect!`'s `b > a` hold by construction:

```julia
if !(a < c < b)
    return ia, ib, false
end
```

Keeping the bracket is the conservative branch, not a stall: the caller's `B - A < gamma * (b - a)` test then fails and it bisects, so the line search still makes progress.

This is not a regression — the guard reads the same in 7.7.1 and earlier. What changed for the workload that found it was only the trajectory: LineSearches 7.7.1 + Optim 2.2.2 was green on the same code, LineSearches 7.8.0 + Optim 2.3.0 walks a few iterations further into convergence and lands on it.

## Tests

Three cases in `test/errors.jl`, next to the existing `cstep outside its bracket` invariant test, calling `update!` directly on a well-formed bracket `[0, 1]`. On master they return `(0.0, 0.0)`, `(1.0, 1.0)` and `(NaN, 1.0)`; with the change all three return `(0.0, 1.0)`. `ϕdϕ` is an `error(...)` stub, since none of these branches may reach it.

Full test suite green.

## Not in scope

`secant2!`'s second secant is guarded by `a <= c <= b`, so it evaluates `ϕdϕ` at an endpoint and then discards the result once `update!` declines to narrow. Tightening that to `a < c < b` would save the evaluation, but it changes iteration counts, so it seemed better kept separate from a correctness fix.

---

*This pull request was written with the assistance of generative AI.*
